### PR TITLE
Fix for ArrayIndexOutOfBoundsException on Windows

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitPublisher.java
@@ -121,7 +121,7 @@ public class PitPublisher extends Recorder implements SimpleBuildStep {
       if (StringUtils.isBlank(base)) {
         moduleName = String.valueOf(i == 0 ? null : i);
       } else {
-        moduleName = report.getRemote().replace(base, "").split("/")[1];
+        moduleName = report.getRemote().replace(base, "").split("[/\\\\]")[1];
       }
 
       final FilePath targetPath = new FilePath(buildTarget, "mutation-report-" + moduleName);


### PR DESCRIPTION
This change fixes an ArrayIndexOutOfBoundsException that occurs when using the PIT plugin on Windows.  The failure was due to code incorrectly assuming the path separator character is always "/", which, of course, it isn't on Windows.

Here are the circumstances surrounding the original failure:

base=abstractBuild.getModuleRoot().getRemote()="E:\jenkins\workspace\MakeLdif-Gradle"
report.getRemote()="E:\jenkins\workspace\MakeLdif-Gradle\build\reports\pitest\mutations.xml"

Mutation Statistics: **\build\reports\pitest\mutations.xml

Looking for PIT reports in E:\jenkins\workspace\MakeLdif-Gradle
Publishing mutation report: E:\jenkins\workspace\MakeLdif-Gradle\build\reports\pitest\mutations.xml
ERROR: Build step failed with exception
java.lang.ArrayIndexOutOfBoundsException: 1
	at org.jenkinsci.plugins.pitmutation.PitPublisher.publishReports(PitPublisher.java:124)
	at org.jenkinsci.plugins.pitmutation.PitPublisher.perform(PitPublisher.java:81)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:78)
	at hudson.tasks.BuildStepMonitor$3.perform(BuildStepMonitor.java:45)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:779)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:720)
	at hudson.model.Build$BuildExecution.post2(Build.java:186)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:665)
	at hudson.model.Run.execute(Run.java:1753)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:98)
	at hudson.model.Executor.run(Executor.java:405)
Build step 'Record Pit mutation testing report' marked build as failure
Sending e-mails to: CKilbride@medline.com
Finished: FAILURE