### PR TITLE
Fix Windows file separators.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitBuildAction.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 @Slf4j
 public class PitBuildAction implements HealthReportingAction, StaplerProxy {
 
-    private static final Pattern MUTATION_REPORT_PATTERN = Pattern.compile(".*mutation-report-([^/]*).*");
+    private static final Pattern MUTATION_REPORT_PATTERN = Pattern.compile(".*mutation-report-([^/\\\\]*).*");
 
     @Getter
     private Run<?, ?> owner;

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitPublisher.java
@@ -148,7 +148,12 @@ public class PitPublisher extends Recorder implements SimpleBuildStep {
             if (StringUtils.isBlank(base)) {
                 moduleName = String.valueOf(i == 0 ? null : i);
             } else {
-                moduleName = report.getRemote().replace(base, "").split("/")[1];
+                String[] partsFromRemoteWithoutBase = report.getRemote().replace(base, "").split("[/\\\\]");
+                if (partsFromRemoteWithoutBase.length > 1) {
+                    moduleName = partsFromRemoteWithoutBase[1];
+                } else {
+                    moduleName = String.valueOf(i == 0 ? null : i);
+                }
             }
 
             final FilePath targetPath = new FilePath(buildTarget, "mutation-report-" + moduleName);

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/targets/MutatedClass.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/targets/MutatedClass.java
@@ -59,11 +59,11 @@ public class MutatedClass extends MutationResult<MutatedClass> {
 
     @Override
     public String getSourceFileContent() {
+        String sourceFilePath = getOwner().getRootDir() + File.separator + "mutation-report-" + getParent().getParent().getName() + File.separator + package_ + File.separator + fileName;
         try {
-            return new TextFile(new File(getOwner().getRootDir(), "mutation-report-" + getParent().getParent().getName() + "/" + package_ + File.separator + fileName)).read();
+            return new TextFile(new File(sourceFilePath)).read();
         } catch (IOException exception) {
-            return "Could not read source file: " + getOwner().getRootDir().getPath()
-                + "/mutation-report/" + package_ + File.separator + fileName + "\n";
+            return "Could not read source file: " + sourceFilePath + "\n";
         }
     }
 


### PR DESCRIPTION
Hello!

The current state of master does not work correctly if Jenkins is installed on Windows OS.
File separators are written incorrectly. Unix-style separators are used instead of universal ones.
I fixed this situation for master.
Please accept this pull request.
Best wishes.