### PR TITLE
Fixed display of parent links in the report.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/pitmutation/targets/MutationResult/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pitmutation/targets/MutationResult/index.jelly
@@ -4,8 +4,11 @@
         <st:include it="${it.owner}" page="sidepanel.jelly"/>
         <l:main-panel>
             <h1>${it.displayName}</h1>
-            <j:forEach var="parent" items="${it.parents}">
+            <j:forEach var="parent" items="${it.parents}" indexVar="i">
                 <a href="${it.relativeUrl(parent)}">${parent.xmlTransform(parent.name)}</a>
+                <j:if test="${i != it.parents.size() - 1}">
+                    <b> / </b>
+                </j:if>
             </j:forEach>
             <h2>Mutation Statistics</h2>
             <table>


### PR DESCRIPTION
Hello!

Actual view of parent links in the report: "Aggregated Reportsmodulepackage".
Fixed view of parent links in the report: "Aggregated Reports / module / package".
Please accept this pull request.
Best wishes.