### PR TITLE
Fixes JENKINS-68990 and adds improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Configure report path, e.g. `target/pit-reports/**/mutations.xml` for a Maven bu
 ## Jenkins Pipeline
 You can use the following step in pipeline to use this plugin in pipeline:
 
-`pitmutation killRatioMustImprove: false, minimumKillRatio: 50.0, mutationStatsFile: '**/target/pit-reports/**/mutations.xml'`
+`pitmutation ignoreMissingReports: false, killRatioMustImprove: false, minimumKillRatio: 50.0, mutationStatsFile: '**/target/pit-reports/**/mutations.xml'`
 
 The plugin needs the XML and HTML output from PIT. Also make sure
 that a clean target is executed before building, otherwise PIT will

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>pitmutation</artifactId>
-    <version>1.1-6-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Jenkins PIT Mutation Plugin</name>
     <packaging>hpi</packaging>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/pitmutation</url>
@@ -23,7 +23,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.414</jenkins.version>
     </properties>
 
     <developers>
@@ -89,20 +89,20 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.0.0</version>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.4.0</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hamcrest</groupId>
-                    <artifactId>hamcrest-core</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -137,8 +137,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -149,7 +149,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <source>8</source>
+                    <source>17</source>
                 </configuration>
             </plugin>
             <plugin>
@@ -171,7 +171,14 @@
             <plugin>
                 <groupId>org.pitest</groupId>
                 <artifactId>pitest-maven</artifactId>
-                <version>1.10.4</version>
+                <version>1.14.2</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.pitest</groupId>
+                        <artifactId>pitest-junit5-plugin</artifactId>
+                        <version>1.1.1</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <targetClasses>
                         <param>org.jenkinsci.plugins.pitmutation.*</param>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>pitmutation</artifactId>
-    <version>1.1-5-SNAPSHOT</version>
+    <version>1.1-6-SNAPSHOT</version>
     <name>Jenkins PIT Mutation Plugin</name>
     <packaging>hpi</packaging>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/pitmutation</url>

--- a/pom.xml
+++ b/pom.xml
@@ -9,21 +9,21 @@
     </parent>
 
     <artifactId>pitmutation</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.2</version>
     <name>Jenkins PIT Mutation Plugin</name>
     <packaging>hpi</packaging>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/pitmutation</url>
 
     <scm>
-        <connection>scm:git:ssh://git@github.com/jenkinsci/pitmutation-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/pitmutation-plugin.git</developerConnection>
+        <connection>scm:git:git://git@github.com/jenkinsci/pitmutation-plugin.git</connection>
+        <developerConnection>scm:git:git://git@github.com/jenkinsci/pitmutation-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/pitmutation-plugin</url>
         <tag>HEAD</tag>
     </scm>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jenkins.version>2.414</jenkins.version>
+        <jenkins.version>2.361.4</jenkins.version>
     </properties>
 
     <developers>
@@ -37,6 +37,12 @@
             <name>Benjamin Sproule</name>
             <email>benjamin@benjaminsproule.com</email>
         </developer>
+        <developer>
+            <id>vasilej</id>
+            <name>Vasile Jureschi</name>
+            <email>vasile.jureschi@gmail.com</email>
+        </developer>
+
     </developers>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.54</version>
+        <version>4.71</version>
         <relativePath/>
     </parent>
 
@@ -15,8 +15,8 @@
     <url>http://wiki.jenkins-ci.org/display/JENKINS/pitmutation</url>
 
     <scm>
-        <connection>scm:git:git://git@github.com/jenkinsci/pitmutation-plugin.git</connection>
-        <developerConnection>scm:git:git://git@github.com/jenkinsci/pitmutation-plugin.git</developerConnection>
+        <connection>scm:git:ssh://git@github.com/jenkinsci/pitmutation-plugin.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/pitmutation-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/pitmutation-plugin</url>
         <tag>HEAD</tag>
     </scm>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.28</version>
             <scope>provided</scope>
         </dependency>
 
@@ -122,7 +122,7 @@
             <plugin>
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
-                <version>3.38</version>
+                <version>3.47</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,14 +9,14 @@
     </parent>
 
     <artifactId>pitmutation</artifactId>
-    <version>1.0-19-SNAPSHOT</version>
+    <version>1.1-4-SNAPSHOT</version>
     <name>Jenkins PIT Mutation Plugin</name>
     <packaging>hpi</packaging>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/pitmutation</url>
 
     <scm>
-        <connection>scm:git:ssh://git@github.com/jenkinsci/pitmutation-plugin.git</connection>
-        <developerConnection>scm:git:ssh://git@github.com/jenkinsci/pitmutation-plugin.git</developerConnection>
+        <connection>scm:git:git://git@github.com/jenkinsci/pitmutation-plugin.git</connection>
+        <developerConnection>scm:git:git://git@github.com/jenkinsci/pitmutation-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/pitmutation-plugin</url>
         <tag>HEAD</tag>
     </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,19 @@
     </pluginRepositories>
 
     <dependencies>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.14.1</version>
+        </dependency>
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>pitmutation</artifactId>
-    <version>1.1-4-SNAPSHOT</version>
+    <version>1.1-5-SNAPSHOT</version>
     <name>Jenkins PIT Mutation Plugin</name>
     <packaging>hpi</packaging>
     <url>http://wiki.jenkins-ci.org/display/JENKINS/pitmutation</url>
@@ -74,11 +74,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-digester3</artifactId>
-            <version>3.2</version>
-        </dependency>
         <dependency>
             <groupId>org.jenkins-ci</groupId>
             <artifactId>symbol-annotation</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/DescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/DescriptorImpl.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Publisher;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * The type Descriptor.
+ */
+@Extension
+@Symbol("pitmutation")
+public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+  /**
+   * Instantiates a new Descriptor.
+   */
+  public DescriptorImpl() {
+    super(PitPublisher.class);
+  }
+
+  @Override
+  public String getDisplayName() {
+    return Messages.PitPublisher_DisplayName();
+  }
+
+  @Override
+  public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+    return true;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+    req.bindParameters(this, "pitmutation");
+    save();
+    return super.configure(req, formData);
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/FileProcessor.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/FileProcessor.java
@@ -1,0 +1,53 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.FilePath;
+import org.apache.commons.lang.StringUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Optional.ofNullable;
+
+public class FileProcessor {
+
+  public static final String SINGLE_MODULE_REPORT_FOLDER = "mutation-report-all";
+  public static final String MULTI_MODULE_REPORT_FORMAT = "mutation-report-%s";
+
+  public void copySingleModuleReport(FilePath source, FilePath buildTarget) throws IOException, InterruptedException {
+    copyMutationReports(source, buildTarget, SINGLE_MODULE_REPORT_FOLDER);
+  }
+
+  public void copyMultiModuleReport(FilePath source, FilePath buildTarget, String module) throws IOException, InterruptedException {
+    copyMutationReports(source, buildTarget, String.format(MULTI_MODULE_REPORT_FORMAT, module));
+  }
+
+  private void copyMutationReports(FilePath source, FilePath buildTarget, String mutationFilePath) throws IOException,
+                                                                                                          InterruptedException {
+    var targetPath = new FilePath(buildTarget, mutationFilePath);
+    var parent = ofNullable(source.getParent()).orElseThrow(() -> new IOException("Mutation file not found"));
+    parent.copyRecursiveTo(targetPath);
+  }
+
+  public Map<FilePath, String> getNames(FilePath[] reports, String base) {
+    Map<FilePath, String> names = new HashMap<>();
+    for (int i = 0; i < reports.length; i++) {
+      FilePath report = reports[i];
+
+      final String moduleName;
+      if (StringUtils.isBlank(base)) {
+        moduleName = String.valueOf(i == 0 ? null : i);
+      } else {
+        String[] partsFromRemoteWithoutBase = report.getRemote().replace(base, "").split("[/\\\\]");
+        if (partsFromRemoteWithoutBase.length > 1) {
+          moduleName = partsFromRemoteWithoutBase[1];
+        } else {
+          moduleName = String.valueOf(i == 0 ? null : i);
+        }
+      }
+
+      names.put(report, moduleName);
+    }
+    return names;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/MustImproveCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/MustImproveCondition.java
@@ -1,0 +1,22 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.pitmutation.targets.MutationStats;
+
+import static hudson.model.Result.SUCCESS;
+import static hudson.model.Result.UNSTABLE;
+
+class MustImproveCondition implements Condition {
+  @Override
+  public Result decideResult(final PitBuildAction action) {
+    PitBuildAction previousAction = action.getPreviousAction();
+    if (previousAction != null) {
+      MutationStats previousStats = previousAction.getReport().getMutationStats();
+      return action.getReport().getMutationStats().getKillPercent() >= previousStats.getKillPercent() ?
+             SUCCESS :
+             UNSTABLE;
+    } else {
+      return SUCCESS;
+    }
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/Mutation.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/Mutation.java
@@ -17,6 +17,7 @@ public class Mutation {
   private String sourceFile;
   private String mutatedClass;
   private String mutatedMethod;
+  private int numberOfTestsRun;
   private int lineNumber;
   private String mutator;
   /**

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/Mutation.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/Mutation.java
@@ -1,30 +1,242 @@
 package org.jenkinsci.plugins.pitmutation;
 
-import lombok.Data;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
+ * `
+ *
  * @author edward
  */
-@Data
 public class Mutation {
-    private boolean detected;
-    private String status;
-    private String sourceFile;
-    private String mutatedClass;
-    private String mutatedMethod;
-    private int lineNumber;
-    private String mutator;
-    private int index;
-    private String killingTest;
-    private String methodDescription;
-    private String description;
-    private String block;
+  private boolean detected;
+  private String status;
+  @JsonProperty("sourceFile")
+  private String sourceFile;
+  private String mutatedClass;
+  private String mutatedMethod;
+  private int lineNumber;
+  private String mutator;
+  private List<Integer> indexes = new ArrayList<>();
+  private String killingTest;
+  private String methodDescription;
+  private String description;
+  private List<String> blocks = new ArrayList<>();
 
-    public String getMutatorClass() {
-        int lastDot = mutator.lastIndexOf('.');
-        String className = mutator.substring(lastDot + 1);
-        return className.endsWith("Mutator")
-            ? className.substring(0, className.length() - 7)
-            : className;
+  public Mutation() {
+  }
+
+  public String getMutatorClass() {
+    int lastDot = mutator.lastIndexOf('.');
+    String className = mutator.substring(lastDot + 1);
+    return className.endsWith("Mutator") ? className.substring(0, className.length() - 7) : className;
+  }
+
+  public boolean isDetected() {
+    return this.detected;
+  }
+
+  public String getStatus() {
+    return this.status;
+  }
+
+  public String getSourceFile() {
+    return this.sourceFile;
+  }
+
+  public String getMutatedClass() {
+    return this.mutatedClass;
+  }
+
+  public String getMutatedMethod() {
+    return this.mutatedMethod;
+  }
+
+  public int getLineNumber() {
+    return this.lineNumber;
+  }
+
+  public String getMutator() {
+    return this.mutator;
+  }
+
+  public List<Integer> getIndexes() {
+    return this.indexes;
+  }
+
+  public String getKillingTest() {
+    return this.killingTest;
+  }
+
+  public String getMethodDescription() {
+    return this.methodDescription;
+  }
+
+  public String getDescription() {
+    return this.description;
+  }
+
+  public List<String> getBlocks() {
+    return this.blocks;
+  }
+
+  public void setDetected(boolean detected) {
+    this.detected = detected;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public void setSourceFile(String sourceFile) {
+    this.sourceFile = sourceFile;
+  }
+
+  public void setMutatedClass(String mutatedClass) {
+    this.mutatedClass = mutatedClass;
+  }
+
+  public void setMutatedMethod(String mutatedMethod) {
+    this.mutatedMethod = mutatedMethod;
+  }
+
+  public void setLineNumber(int lineNumber) {
+    this.lineNumber = lineNumber;
+  }
+
+  public void setMutator(String mutator) {
+    this.mutator = mutator;
+  }
+
+  public void setIndexes(List<Integer> indexes) {
+    this.indexes = indexes;
+  }
+
+  public void setKillingTest(String killingTest) {
+    this.killingTest = killingTest;
+  }
+
+  public void setMethodDescription(String methodDescription) {
+    this.methodDescription = methodDescription;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public void setBlocks(List<String> blocks) {
+    this.blocks = blocks;
+  }
+
+  public boolean equals(final Object o) {
+    if (o == this) {return true;}
+    if (!(o instanceof Mutation)) {return false;}
+    final Mutation other = (Mutation) o;
+    if (!other.canEqual((Object) this)) {return false;}
+    if (this.isDetected() != other.isDetected()) {return false;}
+    final Object this$status = this.getStatus();
+    final Object other$status = other.getStatus();
+    if (this$status == null ? other$status != null : !this$status.equals(other$status)) {return false;}
+    final Object this$sourceFile = this.getSourceFile();
+    final Object other$sourceFile = other.getSourceFile();
+    if (this$sourceFile == null ? other$sourceFile != null : !this$sourceFile.equals(other$sourceFile)) {return false;}
+    final Object this$mutatedClass = this.getMutatedClass();
+    final Object other$mutatedClass = other.getMutatedClass();
+    if (this$mutatedClass == null ? other$mutatedClass != null : !this$mutatedClass.equals(other$mutatedClass)) {
+      return false;
     }
+    final Object this$mutatedMethod = this.getMutatedMethod();
+    final Object other$mutatedMethod = other.getMutatedMethod();
+    if (this$mutatedMethod == null ? other$mutatedMethod != null : !this$mutatedMethod.equals(other$mutatedMethod)) {
+      return false;
+    }
+    if (this.getLineNumber() != other.getLineNumber()) {return false;}
+    final Object this$mutator = this.getMutator();
+    final Object other$mutator = other.getMutator();
+    if (this$mutator == null ? other$mutator != null : !this$mutator.equals(other$mutator)) {return false;}
+    final Object this$indexes = this.getIndexes();
+    final Object other$indexes = other.getIndexes();
+    if (this$indexes == null ? other$indexes != null : !this$indexes.equals(other$indexes)) {return false;}
+    final Object this$killingTest = this.getKillingTest();
+    final Object other$killingTest = other.getKillingTest();
+    if (this$killingTest == null ? other$killingTest != null : !this$killingTest.equals(other$killingTest)) {
+      return false;
+    }
+    final Object this$methodDescription = this.getMethodDescription();
+    final Object other$methodDescription = other.getMethodDescription();
+    if (this$methodDescription == null ?
+        other$methodDescription != null :
+        !this$methodDescription.equals(other$methodDescription)) {return false;}
+    final Object this$description = this.getDescription();
+    final Object other$description = other.getDescription();
+    if (this$description == null ? other$description != null : !this$description.equals(other$description)) {
+      return false;
+    }
+    final Object this$blocks = this.getBlocks();
+    final Object other$blocks = other.getBlocks();
+    if (this$blocks == null ? other$blocks != null : !this$blocks.equals(other$blocks)) {return false;}
+    return true;
+  }
+
+  protected boolean canEqual(final Object other) {
+    return other instanceof Mutation;
+  }
+
+  public int hashCode() {
+    final int PRIME = 59;
+    int result = 1;
+    result = result * PRIME + (this.isDetected() ? 79 : 97);
+    final Object $status = this.getStatus();
+    result = result * PRIME + ($status == null ? 43 : $status.hashCode());
+    final Object $sourceFile = this.getSourceFile();
+    result = result * PRIME + ($sourceFile == null ? 43 : $sourceFile.hashCode());
+    final Object $mutatedClass = this.getMutatedClass();
+    result = result * PRIME + ($mutatedClass == null ? 43 : $mutatedClass.hashCode());
+    final Object $mutatedMethod = this.getMutatedMethod();
+    result = result * PRIME + ($mutatedMethod == null ? 43 : $mutatedMethod.hashCode());
+    result = result * PRIME + this.getLineNumber();
+    final Object $mutator = this.getMutator();
+    result = result * PRIME + ($mutator == null ? 43 : $mutator.hashCode());
+    final Object $indexes = this.getIndexes();
+    result = result * PRIME + ($indexes == null ? 43 : $indexes.hashCode());
+    final Object $killingTest = this.getKillingTest();
+    result = result * PRIME + ($killingTest == null ? 43 : $killingTest.hashCode());
+    final Object $methodDescription = this.getMethodDescription();
+    result = result * PRIME + ($methodDescription == null ? 43 : $methodDescription.hashCode());
+    final Object $description = this.getDescription();
+    result = result * PRIME + ($description == null ? 43 : $description.hashCode());
+    final Object $blocks = this.getBlocks();
+    result = result * PRIME + ($blocks == null ? 43 : $blocks.hashCode());
+    return result;
+  }
+
+  public String toString() {
+    return "Mutation(detected="
+           + this.isDetected()
+           + ", status="
+           + this.getStatus()
+           + ", sourceFile="
+           + this.getSourceFile()
+           + ", mutatedClass="
+           + this.getMutatedClass()
+           + ", mutatedMethod="
+           + this.getMutatedMethod()
+           + ", lineNumber="
+           + this.getLineNumber()
+           + ", mutator="
+           + this.getMutator()
+           + ", indexes="
+           + this.getIndexes()
+           + ", killingTest="
+           + this.getKillingTest()
+           + ", methodDescription="
+           + this.getMethodDescription()
+           + ", description="
+           + this.getDescription()
+           + ", blocks="
+           + this.getBlocks()
+           + ")";
+  }
 }

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/Mutation.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/Mutation.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.pitmutation;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,19 +10,29 @@ import java.util.List;
  *
  * @author edward
  */
+@Data
 public class Mutation {
   private boolean detected;
   private String status;
-  @JsonProperty("sourceFile")
   private String sourceFile;
   private String mutatedClass;
   private String mutatedMethod;
   private int lineNumber;
   private String mutator;
+  /**
+   * @deprecated from 1 .9 the mutation library generates a list of indexes <a href="https://issues.jenkins.io/browse/JENKINS-68990">JENKINS-68990</a>
+   */
+  @Deprecated(forRemoval = true, since = "1.9")
+  private Integer index;
   private List<Integer> indexes = new ArrayList<>();
   private String killingTest;
   private String methodDescription;
   private String description;
+  /**
+   * @deprecated from 1 .9 the mutation library generates a list of blocks <a href="https://issues.jenkins.io/browse/JENKINS-68990">JENKINS-68990</a>
+   */
+  @Deprecated(forRemoval = true, since = "1.9")
+  private String block;
   private List<String> blocks = new ArrayList<>();
 
   public Mutation() {
@@ -34,209 +44,8 @@ public class Mutation {
     return className.endsWith("Mutator") ? className.substring(0, className.length() - 7) : className;
   }
 
-  public boolean isDetected() {
-    return this.detected;
-  }
-
-  public String getStatus() {
-    return this.status;
-  }
-
-  public String getSourceFile() {
-    return this.sourceFile;
-  }
-
-  public String getMutatedClass() {
-    return this.mutatedClass;
-  }
-
-  public String getMutatedMethod() {
-    return this.mutatedMethod;
-  }
-
-  public int getLineNumber() {
-    return this.lineNumber;
-  }
-
-  public String getMutator() {
-    return this.mutator;
-  }
-
-  public List<Integer> getIndexes() {
-    return this.indexes;
-  }
-
-  public String getKillingTest() {
-    return this.killingTest;
-  }
-
-  public String getMethodDescription() {
-    return this.methodDescription;
-  }
-
-  public String getDescription() {
-    return this.description;
-  }
-
-  public List<String> getBlocks() {
-    return this.blocks;
-  }
-
-  public void setDetected(boolean detected) {
-    this.detected = detected;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public void setSourceFile(String sourceFile) {
-    this.sourceFile = sourceFile;
-  }
-
-  public void setMutatedClass(String mutatedClass) {
-    this.mutatedClass = mutatedClass;
-  }
-
-  public void setMutatedMethod(String mutatedMethod) {
-    this.mutatedMethod = mutatedMethod;
-  }
-
-  public void setLineNumber(int lineNumber) {
-    this.lineNumber = lineNumber;
-  }
-
-  public void setMutator(String mutator) {
-    this.mutator = mutator;
-  }
-
-  public void setIndexes(List<Integer> indexes) {
-    this.indexes = indexes;
-  }
-
-  public void setKillingTest(String killingTest) {
-    this.killingTest = killingTest;
-  }
-
-  public void setMethodDescription(String methodDescription) {
-    this.methodDescription = methodDescription;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public void setBlocks(List<String> blocks) {
-    this.blocks = blocks;
-  }
-
-  public boolean equals(final Object o) {
-    if (o == this) {return true;}
-    if (!(o instanceof Mutation)) {return false;}
-    final Mutation other = (Mutation) o;
-    if (!other.canEqual((Object) this)) {return false;}
-    if (this.isDetected() != other.isDetected()) {return false;}
-    final Object this$status = this.getStatus();
-    final Object other$status = other.getStatus();
-    if (this$status == null ? other$status != null : !this$status.equals(other$status)) {return false;}
-    final Object this$sourceFile = this.getSourceFile();
-    final Object other$sourceFile = other.getSourceFile();
-    if (this$sourceFile == null ? other$sourceFile != null : !this$sourceFile.equals(other$sourceFile)) {return false;}
-    final Object this$mutatedClass = this.getMutatedClass();
-    final Object other$mutatedClass = other.getMutatedClass();
-    if (this$mutatedClass == null ? other$mutatedClass != null : !this$mutatedClass.equals(other$mutatedClass)) {
-      return false;
-    }
-    final Object this$mutatedMethod = this.getMutatedMethod();
-    final Object other$mutatedMethod = other.getMutatedMethod();
-    if (this$mutatedMethod == null ? other$mutatedMethod != null : !this$mutatedMethod.equals(other$mutatedMethod)) {
-      return false;
-    }
-    if (this.getLineNumber() != other.getLineNumber()) {return false;}
-    final Object this$mutator = this.getMutator();
-    final Object other$mutator = other.getMutator();
-    if (this$mutator == null ? other$mutator != null : !this$mutator.equals(other$mutator)) {return false;}
-    final Object this$indexes = this.getIndexes();
-    final Object other$indexes = other.getIndexes();
-    if (this$indexes == null ? other$indexes != null : !this$indexes.equals(other$indexes)) {return false;}
-    final Object this$killingTest = this.getKillingTest();
-    final Object other$killingTest = other.getKillingTest();
-    if (this$killingTest == null ? other$killingTest != null : !this$killingTest.equals(other$killingTest)) {
-      return false;
-    }
-    final Object this$methodDescription = this.getMethodDescription();
-    final Object other$methodDescription = other.getMethodDescription();
-    if (this$methodDescription == null ?
-        other$methodDescription != null :
-        !this$methodDescription.equals(other$methodDescription)) {return false;}
-    final Object this$description = this.getDescription();
-    final Object other$description = other.getDescription();
-    if (this$description == null ? other$description != null : !this$description.equals(other$description)) {
-      return false;
-    }
-    final Object this$blocks = this.getBlocks();
-    final Object other$blocks = other.getBlocks();
-    if (this$blocks == null ? other$blocks != null : !this$blocks.equals(other$blocks)) {return false;}
-    return true;
-  }
-
   protected boolean canEqual(final Object other) {
     return other instanceof Mutation;
   }
 
-  public int hashCode() {
-    final int PRIME = 59;
-    int result = 1;
-    result = result * PRIME + (this.isDetected() ? 79 : 97);
-    final Object $status = this.getStatus();
-    result = result * PRIME + ($status == null ? 43 : $status.hashCode());
-    final Object $sourceFile = this.getSourceFile();
-    result = result * PRIME + ($sourceFile == null ? 43 : $sourceFile.hashCode());
-    final Object $mutatedClass = this.getMutatedClass();
-    result = result * PRIME + ($mutatedClass == null ? 43 : $mutatedClass.hashCode());
-    final Object $mutatedMethod = this.getMutatedMethod();
-    result = result * PRIME + ($mutatedMethod == null ? 43 : $mutatedMethod.hashCode());
-    result = result * PRIME + this.getLineNumber();
-    final Object $mutator = this.getMutator();
-    result = result * PRIME + ($mutator == null ? 43 : $mutator.hashCode());
-    final Object $indexes = this.getIndexes();
-    result = result * PRIME + ($indexes == null ? 43 : $indexes.hashCode());
-    final Object $killingTest = this.getKillingTest();
-    result = result * PRIME + ($killingTest == null ? 43 : $killingTest.hashCode());
-    final Object $methodDescription = this.getMethodDescription();
-    result = result * PRIME + ($methodDescription == null ? 43 : $methodDescription.hashCode());
-    final Object $description = this.getDescription();
-    result = result * PRIME + ($description == null ? 43 : $description.hashCode());
-    final Object $blocks = this.getBlocks();
-    result = result * PRIME + ($blocks == null ? 43 : $blocks.hashCode());
-    return result;
-  }
-
-  public String toString() {
-    return "Mutation(detected="
-           + this.isDetected()
-           + ", status="
-           + this.getStatus()
-           + ", sourceFile="
-           + this.getSourceFile()
-           + ", mutatedClass="
-           + this.getMutatedClass()
-           + ", mutatedMethod="
-           + this.getMutatedMethod()
-           + ", lineNumber="
-           + this.getLineNumber()
-           + ", mutator="
-           + this.getMutator()
-           + ", indexes="
-           + this.getIndexes()
-           + ", killingTest="
-           + this.getKillingTest()
-           + ", methodDescription="
-           + this.getMethodDescription()
-           + ", description="
-           + this.getDescription()
-           + ", blocks="
-           + this.getBlocks()
-           + ")";
-  }
 }

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/MutationReport.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/MutationReport.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 /**
  * @author edward
+ * @author vasile.jureschi
  */
 public class MutationReport {
 
@@ -26,7 +27,6 @@ public class MutationReport {
   public MutationReport(InputStream xmlReport) throws IOException, SAXException {
     this.mutationsByClass = new HashMap<>();
     this.mutationsByPackage = new HashMap<>();
-
 
     //    https://github.com/FasterXML/jackson-dataformat-xml/issues/219
     JacksonXmlModule module = new JacksonXmlModule();

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/MutationReport.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/MutationReport.java
@@ -1,99 +1,85 @@
 package org.jenkinsci.plugins.pitmutation;
 
-import org.apache.commons.digester3.Digester;
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import org.jenkinsci.plugins.pitmutation.targets.MutationStats;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * @author edward
  */
 public class MutationReport {
 
-    private final Map<String, List<Mutation>> mutationsByPackage;
-    private final Map<String, List<Mutation>> mutationsByClass;
-    private int killCount = 0;
+  private final Map<String, List<Mutation>> mutationsByPackage;
 
-    public MutationReport() {
-        this.mutationsByClass = new HashMap<>();
-        this.mutationsByPackage = new HashMap<>();
-    }
+  private final Map<String, List<Mutation>> mutationsByClass;
+  private int killCount = 0;
 
-    public static MutationReport create(InputStream xmlReport) throws IOException, SAXException {
-        return digestMutations(xmlReport);
-    }
+  public MutationReport(InputStream xmlReport) throws IOException, SAXException {
+    this.mutationsByClass = new HashMap<>();
+    this.mutationsByPackage = new HashMap<>();
 
-    private static MutationReport digestMutations(InputStream input) throws IOException, SAXException {
-        Digester digester = new Digester();
-        digester.addObjectCreate("mutations", MutationReport.class);
-        digester.addObjectCreate("mutations/mutation", Mutation.class);
-        digester.addSetNext("mutations/mutation", "addMutation", "org.jenkinsci.plugins.pitmutation.Mutation");
-        digester.addSetProperties("mutations/mutation");
-        digester.addSetNestedProperties("mutations/mutation");
 
-        MutationReport report = digester.parse(input);
-        report.mutationsByClass.forEach((className, mutations) -> {
-            String packageName = packageNameFromClass(className);
-            List<Mutation> existingPackageMutations = report.mutationsByPackage
-                .computeIfAbsent(packageName, k -> new ArrayList<>());
-            mutations.stream().filter(mutation -> !existingPackageMutations.contains(mutation))
-                .forEach(mutation -> report.mutationsByPackage.get(packageName).add(mutation));
-        });
-        return report;
-    }
+    //    https://github.com/FasterXML/jackson-dataformat-xml/issues/219
+    JacksonXmlModule module = new JacksonXmlModule();
+    module.setDefaultUseWrapper(false);
+    XmlMapper xmlMapper = new XmlMapper(module);
+    Mutations mutations = xmlMapper.readValue(xmlReport, Mutations.class);
 
-    /**
-     * Called by digester.
-     *
-     * @param mutation {@link Mutation} to add
-     */
-    public void addMutation(Mutation mutation) {
-        mutationsByClass.computeIfAbsent(mutation.getMutatedClass(), k -> new ArrayList<>())
-            .add(mutation);
-        if (mutation.isDetected()) {
-            killCount++;
-        }
-        mutationsByPackage.computeIfAbsent(packageNameFromClass(mutation.getMutatedClass()), k -> new ArrayList<>())
-            .add(mutation);
-    }
+    mutations.getMutation().forEach(mutation -> {
+      mutationsByClass.computeIfAbsent(mutation.getMutatedClass(), k -> new ArrayList<>()).add(mutation);
+      if (mutation.isDetected()) {
+        killCount++;
+      }
+      mutationsByPackage
+        .computeIfAbsent(packageNameFromClass(mutation.getMutatedClass()), k -> new ArrayList<>())
+        .add(mutation);
 
-    public Collection<Mutation> getMutationsForPackage(String packageName) {
-        return mutationsByPackage.computeIfAbsent(packageName, k -> new ArrayList<>());
-    }
+    });
+  }
 
-    public Map<String, List<Mutation>> getMutationsByPackage() {
-        return mutationsByPackage;
-    }
+  public Collection<Mutation> getMutationsForPackage(String packageName) {
+    return mutationsByPackage.computeIfAbsent(packageName, k -> new ArrayList<>());
+  }
 
-    public Collection<Mutation> getMutationsForClassName(String className) {
-        return mutationsByClass.computeIfAbsent(className, k -> new ArrayList<>());
-    }
+  public Map<String, List<Mutation>> getMutationsByPackage() {
+    return mutationsByPackage;
+  }
 
-    public MutationStats getMutationStats() {
-        return new MutationStats() {
-            @Override
-            public String getTitle() {
-                return "Report Stats";
-            }
+  public Collection<Mutation> getMutationsForClassName(String className) {
+    return mutationsByClass.computeIfAbsent(className, k -> new ArrayList<>());
+  }
 
-            @Override
-            public int getUndetected() {
-                return getTotalMutations() - killCount;
-            }
+  public MutationStats getMutationStats() {
+    return new MutationStats() {
+      @Override
+      public String getTitle() {
+        return "Report Stats";
+      }
 
-            @Override
-            public int getTotalMutations() {
-                return mutationsByClass.values().stream().mapToInt(Collection::size).sum();
-            }
-        };
-    }
+      @Override
+      public int getUndetected() {
+        return getTotalMutations() - killCount;
+      }
 
-    // TODO: Move somewhere out of this class
-    static String packageNameFromClass(String fqcn) {
-        int idx = fqcn.lastIndexOf('.');
-        return fqcn.substring(0, idx != -1 ? idx : 0);
-    }
+      @Override
+      public int getTotalMutations() {
+        return mutationsByClass.values().stream().mapToInt(Collection::size).sum();
+      }
+    };
+  }
+
+  // TODO: Move somewhere out of this class
+  static String packageNameFromClass(String fqcn) {
+    int idx = fqcn.lastIndexOf('.');
+    return fqcn.substring(0, idx != -1 ? idx : 0);
+  }
 }

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/Mutations.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/Mutations.java
@@ -1,0 +1,14 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@AllArgsConstructor
+@Data
+@NoArgsConstructor
+public class Mutations {
+  private List<Mutation> mutation;
+}

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/ParseReportCallable.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/ParseReportCallable.java
@@ -1,0 +1,41 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.FilePath;
+import hudson.remoting.VirtualChannel;
+import org.jenkinsci.remoting.RoleChecker;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * The type Parse report callable.
+ */
+public class ParseReportCallable implements FilePath.FileCallable<FilePath[]> {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String reportFilePath;
+
+  /**
+   * Instantiates a new Parse report callable.
+   *
+   * @param reportFilePath the report file path
+   */
+  public ParseReportCallable(String reportFilePath) {
+    this.reportFilePath = reportFilePath;
+  }
+
+  @Override
+  public FilePath[] invoke(File f, VirtualChannel channel) throws IOException, InterruptedException {
+    FilePath[] r = new FilePath(f).list(reportFilePath);
+    if (r.length < 1) {
+      throw new IOException("No reports found at location:" + reportFilePath);
+    }
+    return r;
+  }
+
+  @Override
+  public void checkRoles(RoleChecker roleChecker) throws SecurityException {
+
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PercentageThresholdCondition.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PercentageThresholdCondition.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.pitmutation.targets.MutationStats;
+
+import static hudson.model.Result.FAILURE;
+import static hudson.model.Result.SUCCESS;
+
+class PercentageThresholdCondition implements Condition {
+  private final float percentage;
+
+  PercentageThresholdCondition(float percentage) {
+    super();
+    this.percentage = percentage;
+  }
+
+  @Override
+  public Result decideResult(PitBuildAction action) {
+    return action.getReport().getMutationStats().getKillPercent() >= percentage ? SUCCESS : FAILURE;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitBuildAction.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static hudson.model.Result.FAILURE;
+
 
 /**
  * @author edward
@@ -45,16 +47,16 @@ public class PitBuildAction implements HealthReportingAction, StaplerProxy {
     }
 
     public PitBuildAction getPreviousAction() {
-        Run<?, ?> b = owner;
+        Run<?, ?> build = owner;
         while (true) {
-            b = b.getPreviousBuild();
-            if (b == null)
+            build = build.getPreviousBuild();
+            if (build == null)
                 return null;
-            if (b.getResult() == Result.FAILURE)
+            if (build.getResult() == FAILURE)
                 continue;
-            PitBuildAction r = b.getAction(PitBuildAction.class);
-            if (r != null)
-                return r;
+            PitBuildAction action = build.getAction(PitBuildAction.class);
+            if (action != null)
+                return action;
         }
     }
 
@@ -121,7 +123,7 @@ public class PitBuildAction implements HealthReportingAction, StaplerProxy {
             if (b == null) {
                 return null;
             }
-            assert b.getResult() != Result.FAILURE : "We asked for the previous not failed build";
+            assert b.getResult() != FAILURE : "We asked for the previous not failed build";
             PitBuildAction r = b.getAction(PitBuildAction.class);
             if (r != null) {
                 return r;

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitBuildAction.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitBuildAction.java
@@ -94,7 +94,7 @@ public class PitBuildAction implements HealthReportingAction, StaplerProxy {
                 } else {
                     name = String.valueOf(i);
                 }
-                reports.put(name, MutationReport.create(files[i].read()));
+                reports.put(name, new MutationReport(files[i].read()));
             }
         } catch (IOException | InterruptedException | SAXException e) {
             e.printStackTrace();

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitLogger.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitLogger.java
@@ -1,0 +1,57 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.pitmutation.targets.MutationStats;
+
+/**
+ * Logging class for various pit information.
+ *
+ * @author edward
+ * @author vasile.jureschi
+ */
+public class PitLogger {
+
+  PitLogger() {
+  }
+
+  public void logResults(TaskListener listener, PitBuildAction action ) {
+    MutationStats mutationStats = action.getReport().getMutationStats();
+    float previousKillPercent = action.getPreviousAction().getReport().getMutationStats().getKillPercent();
+    logCurrent(mutationStats, listener);
+    logPrevious(mutationStats.getKillPercent(),previousKillPercent, listener);
+  }
+
+  public void logMissingReportsIgnored(TaskListener listener) {
+    listener.getLogger().println("Build successful as no reports generated and build set to ignore missing reports. "
+                                 + "If the reports should be present set 'ignoreMissingReports' to false and run the build again to fail the build.");
+  }
+
+  public void logBuildFailedNoReports(TaskListener listener) {
+    listener.getLogger().println("Build failed as no reports generated and build set to not ignore missing reports. "
+                                 + "If no reports should be generated set 'ignoreMissingReports' to true and run the build again to pass the build.");
+  }
+
+  private void logCurrent(MutationStats currentStats, TaskListener listener) {
+    listener
+      .getLogger()
+      .printf("Kill ratio is %f \\u0025 (%d %d)%n",
+              currentStats.getKillPercent(),
+              currentStats.getKillCount(),
+              currentStats.getTotalMutations());
+  }
+
+
+  private void logPrevious(float currentKillPercent, float previousKillPercent, TaskListener listener) {
+    listener.getLogger().println("Previous kill ratio was " + previousKillPercent + "%");
+    listener.getLogger().println("This kill ration is " + currentKillPercent + "%");
+  }
+
+  public void logLookingForReports(TaskListener listener, FilePath workspace) {
+    listener.getLogger().println("Looking for PIT reports in " + workspace.getRemote());
+  }
+
+  public void logPublishReport(TaskListener listener, FilePath workspace) {
+    listener.getLogger().println("Publishing mutation report: " + workspace.getRemote());
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitLogger.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitLogger.java
@@ -15,21 +15,28 @@ public class PitLogger {
   PitLogger() {
   }
 
-  public void logResults(TaskListener listener, PitBuildAction action ) {
+  public void logResults(TaskListener listener, PitBuildAction action) {
     MutationStats mutationStats = action.getReport().getMutationStats();
-    float previousKillPercent = action.getPreviousAction().getReport().getMutationStats().getKillPercent();
+    PitBuildAction previousAction = action.getPreviousAction();
+    if (previousAction != null) {
+      float previousKillPercent = previousAction.getReport().getMutationStats().getKillPercent();
+      logPrevious(mutationStats.getKillPercent(), previousKillPercent, listener);
+    }
     logCurrent(mutationStats, listener);
-    logPrevious(mutationStats.getKillPercent(),previousKillPercent, listener);
   }
 
   public void logMissingReportsIgnored(TaskListener listener) {
-    listener.getLogger().println("Build successful as no reports generated and build set to ignore missing reports. "
-                                 + "If the reports should be present set 'ignoreMissingReports' to false and run the build again to fail the build.");
+    listener
+      .getLogger()
+      .println("Build successful as no reports generated and build set to ignore missing reports. "
+               + "If the reports should be present set 'ignoreMissingReports' to false and run the build again to fail the build.");
   }
 
   public void logBuildFailedNoReports(TaskListener listener) {
-    listener.getLogger().println("Build failed as no reports generated and build set to not ignore missing reports. "
-                                 + "If no reports should be generated set 'ignoreMissingReports' to true and run the build again to pass the build.");
+    listener
+      .getLogger()
+      .println("Build failed as no reports generated and build set to not ignore missing reports. "
+               + "If no reports should be generated set 'ignoreMissingReports' to true and run the build again to pass the build.");
   }
 
   private void logCurrent(MutationStats currentStats, TaskListener listener) {
@@ -53,5 +60,9 @@ public class PitLogger {
 
   public void logPublishReport(TaskListener listener, FilePath workspace) {
     listener.getLogger().println("Publishing mutation report: " + workspace.getRemote());
+  }
+
+  public void log(TaskListener listener, String message) {
+    listener.getLogger().println(message);
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/PitProjectAction.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/PitProjectAction.java
@@ -6,6 +6,8 @@ import org.kohsuke.stapler.StaplerResponse;
 
 import java.io.IOException;
 
+import static hudson.model.Result.FAILURE;
+
 /**
  * @author Ed Kimber
  */
@@ -24,7 +26,7 @@ public class PitProjectAction extends Actionable implements ProminentProjectActi
      */
     public PitBuildAction getLastResult() {
         for (AbstractBuild<?, ?> b = project.getLastSuccessfulBuild(); b != null; b = b.getPreviousNotFailedBuild()) {
-            if (b.getResult() == Result.FAILURE)
+            if (b.getResult() == FAILURE)
                 continue;
             PitBuildAction r = b.getAction(PitBuildAction.class);
             if (r != null)
@@ -44,7 +46,7 @@ public class PitProjectAction extends Actionable implements ProminentProjectActi
      */
     public Integer getLastResultBuild() {
         for (AbstractBuild<?, ?> b = project.getLastSuccessfulBuild(); b != null; b = b.getPreviousNotFailedBuild()) {
-            if (b.getResult() == Result.FAILURE)
+            if (b.getResult() == FAILURE)
                 continue;
             PitBuildAction r = b.getAction(PitBuildAction.class);
             if (r != null)

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/ResultDecider.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/ResultDecider.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.model.Result;
+
+import java.util.Collection;
+import java.util.List;
+
+import static hudson.model.Result.SUCCESS;
+
+/**
+ * Decides if a build is failed or not based on conditions.
+ *
+ * @author edward
+ * @author vasile.jureschi
+ */
+public class ResultDecider {
+
+  private final Collection<Condition> buildConditions;
+
+  protected ResultDecider(PercentageThresholdCondition thresholdCondition) {
+    buildConditions = List.of(thresholdCondition);
+  }
+
+  protected ResultDecider(PercentageThresholdCondition thresholdCondition, MustImproveCondition mustImproveCondition) {
+    buildConditions = List.of(thresholdCondition, mustImproveCondition);
+  }
+
+  /**
+   * Decide build result result.
+   *
+   * @param action the action
+   * @return the worst result from all conditions
+   */
+  public Result decideBuildResult(PitBuildAction action) {
+    Result result = SUCCESS;
+    for (Condition condition : buildConditions) {
+      Result conditionResult = condition.decideResult(action);
+      result = conditionResult.isWorseThan(result) ? conditionResult : result;
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/portlets/PitColumn.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/portlets/PitColumn.java
@@ -52,7 +52,7 @@ public class PitColumn extends ListViewColumn {
         final double doubleValue = percentageFloat.doubleValue();
 
         final int decimalPlaces = 2;
-        BigDecimal bigDecimal = new BigDecimal(doubleValue);
+        BigDecimal bigDecimal =  BigDecimal.valueOf(doubleValue);
 
         // setScale is immutable
         bigDecimal = bigDecimal.setScale(decimalPlaces,

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/targets/ModuleResult.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/targets/ModuleResult.java
@@ -1,15 +1,14 @@
 package org.jenkinsci.plugins.pitmutation.targets;
 
-import static org.jenkinsci.plugins.pitmutation.PitPublisher.MULTI_MODULE_REPORT_FORMAT;
-
-import java.util.Map;
-import java.util.Objects;
-import javax.annotation.Nonnull;
-
-import org.jenkinsci.plugins.pitmutation.MutationReport;
-
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.jenkinsci.plugins.pitmutation.MutationReport;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.jenkinsci.plugins.pitmutation.FileProcessor.MULTI_MODULE_REPORT_FORMAT;
 
 /**
  * @author edward
@@ -17,9 +16,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ModuleResult extends MutationResult<ModuleResult> {
 
-    private MutationReport report;
+    private final MutationReport report;
     @Getter
-    private String name;
+    private final String name;
 
     public ModuleResult(String name, MutationResult parent, MutationReport report) {
         super(name, parent);

--- a/src/main/java/org/jenkinsci/plugins/pitmutation/targets/SingleModuleResult.java
+++ b/src/main/java/org/jenkinsci/plugins/pitmutation/targets/SingleModuleResult.java
@@ -1,16 +1,16 @@
 package org.jenkinsci.plugins.pitmutation.targets;
 
+import hudson.model.Run;
+import org.jenkinsci.plugins.pitmutation.MutationReport;
+import org.jenkinsci.plugins.pitmutation.PitBuildAction;
+
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nonnull;
 
-import org.jenkinsci.plugins.pitmutation.MutationReport;
-import org.jenkinsci.plugins.pitmutation.PitBuildAction;
-import org.jenkinsci.plugins.pitmutation.PitPublisher;
-
-import hudson.model.Run;
+import static org.jenkinsci.plugins.pitmutation.FileProcessor.SINGLE_MODULE_REPORT_FOLDER;
 
 public class SingleModuleResult extends MutationResult<SingleModuleResult> {
 
@@ -57,7 +57,7 @@ public class SingleModuleResult extends MutationResult<SingleModuleResult> {
 
     @Override
     protected String getMutationReportDirectory() {
-        return PitPublisher.SINGLE_MODULE_REPORT_FOLDER;
+        return SINGLE_MODULE_REPORT_FOLDER;
     }
 
     @Override

--- a/src/main/resources/org/jenkinsci/plugins/pitmutation/PitPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pitmutation/PitPublisher/config.jelly
@@ -23,4 +23,9 @@
              description="The build will be marked unstable if the kill ratio is lower than the last build.">
         <f:checkbox/>
     </f:entry>
+    <f:entry title="Ignore missing reports"
+             field="ignoreMissingReports"
+             description="The build will pass even if no reports are found.">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/MustImproveConditionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/MustImproveConditionTest.java
@@ -1,0 +1,64 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.pitmutation.targets.MutationResult;
+import org.jenkinsci.plugins.pitmutation.targets.MutationStats;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.stream.Stream;
+
+import static hudson.model.Result.SUCCESS;
+import static hudson.model.Result.UNSTABLE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MustImproveConditionTest {
+
+  @TestFactory
+  Stream<DynamicTest> testFactory() {
+    return Stream
+      .of(new TestCase(null, 90f, SUCCESS, "noPreviousAction"),
+          new TestCase(85f, 90f, SUCCESS, "currentKillPercentGreater"),
+          new TestCase(85f, 85f, SUCCESS, "currentKillPercentEqual"),
+          new TestCase(85f, 80f, UNSTABLE, "currentKillPercentLess"))
+      .map(testCase -> dynamicTest(testCase.name, () -> {
+        PitBuildAction action = mock(PitBuildAction.class);
+        PitBuildAction previousAction = mock(PitBuildAction.class);
+        MutationResult currentReport = mock(MutationResult.class);
+        MutationResult previousReport = mock(MutationResult.class);
+        MutationStats currentStats = mock(MutationStats.class);
+        MutationStats previousStats = mock(MutationStats.class);
+
+        when(action.getReport()).thenReturn(currentReport);
+        when(currentReport.getMutationStats()).thenReturn(currentStats);
+        when(currentStats.getKillPercent()).thenReturn(testCase.currentKillPercent);
+
+        if (testCase.previousKillPercent != null) {
+          when(action.getPreviousAction()).thenReturn(previousAction);
+          when(previousAction.getReport()).thenReturn(previousReport);
+          when(previousReport.getMutationStats()).thenReturn(previousStats);
+          when(previousStats.getKillPercent()).thenReturn(testCase.previousKillPercent);
+        }
+
+        MustImproveCondition condition = new MustImproveCondition();
+        assertEquals(testCase.expectedResult, condition.decideResult(action));
+      }));
+  }
+
+  private static class TestCase {
+    Float previousKillPercent;
+    float currentKillPercent;
+    Result expectedResult;
+    String name;
+
+    TestCase(Float previousKillPercent, float currentKillPercent, Result expectedResult, String name) {
+      this.previousKillPercent = previousKillPercent;
+      this.currentKillPercent = currentKillPercent;
+      this.expectedResult = expectedResult;
+      this.name = name;
+    }
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportTest.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.pitmutation;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import java.io.ByteArrayInputStream;
@@ -17,7 +17,7 @@ import static org.hamcrest.core.Is.is;
 /**
  * @author edward
  */
-public class MutationReportTest {
+class MutationReportTest {
 
   private static final String MUTATIONS_OLD = "<mutations>"
                                               + "<mutation detected='true' status='NO_COVERAGE'>\n"
@@ -65,26 +65,26 @@ public class MutationReportTest {
 
   private InputStream mutationsXml;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     mutationsXml = getClass().getResourceAsStream("testmutations-00.xml");
   }
 
   @Test
-  public void packageNameFinder() {
+  void packageNameFinder() {
     assertThat(MutationReport.packageNameFromClass("xxx.yyy.zzz.Foo"), is("xxx.yyy.zzz"));
     assertThat(MutationReport.packageNameFromClass("Foo"), is(""));
   }
 
   @Test
-  public void countsKills() throws IOException, SAXException {
+  void countsKills() throws IOException, SAXException {
     MutationReport report = new MutationReport(mutationsXml);
     assertThat(report.getMutationStats().getKillCount(), is(5));
     assertThat(report.getMutationStats().getTotalMutations(), is(16));
   }
 
   @Test
-  public void sortsMutationsByClassName() throws IOException, SAXException {
+  void sortsMutationsByClassName() throws IOException, SAXException {
     MutationReport report = new MutationReport(mutationsXml);
     Collection<Mutation> mutations =
       report.getMutationsForClassName("org.jenkinsci.plugins.pitmutation.MutationReport");
@@ -92,14 +92,14 @@ public class MutationReportTest {
   }
 
   @Test
-  public void indexesMutationsByPackage() throws IOException, SAXException {
+  void indexesMutationsByPackage() throws IOException, SAXException {
     MutationReport report = new MutationReport(mutationsXml);
     assertThat(report.getMutationsForPackage("org.jenkinsci.plugins.pitmutation"), hasSize(16));
     assertThat(report.getMutationsForPackage(""), hasSize(0));
   }
 
   @Test
-  public void canDigestAMutation() throws IOException, SAXException {
+  void canDigestAMutation() throws IOException, SAXException {
     MutationReport report = new MutationReport(new ByteArrayInputStream(MUTATIONS.getBytes("UTF-8")));
 
     assertThat(report.getMutationStats().getTotalMutations(), is(2));
@@ -120,7 +120,7 @@ public class MutationReportTest {
   }
 
   @Test
-  public void canDigestAMutationOlderMutations() throws IOException, SAXException {
+  void canDigestAMutationOlderMutations() throws IOException, SAXException {
     MutationReport report = new MutationReport(new ByteArrayInputStream(MUTATIONS_OLD.getBytes("UTF-8")));
 
     assertThat(report.getMutationStats().getTotalMutations(), is(2));

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportTest.java
@@ -27,7 +27,7 @@ public class MutationReportTest {
             + "<mutatedMethod>getSize</mutatedMethod>\n"
             + "<lineNumber>54</lineNumber>\n"
             + "<mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>\n"
-            + "<index>5</index>\n"
+            + "<indexes><index>5</index></indexes>\n"
             + "<killingTest/>\n"
             + "</mutation>"
             + "<mutation detected='false' status='KILLED'>"
@@ -36,8 +36,8 @@ public class MutationReportTest {
             + "<mutatedMethod>getSize</mutatedMethod>"
             + "<lineNumber>57</lineNumber>"
             + "<mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>"
-            + "<index>6</index>"
-            + "<block>3</block>"
+            + "<indexes><index>6</index></indexes>"
+            + "<blocks><block>3</block></blocks>"
             + "<killingTest/>"
             + "</mutation>"
             + "</mutations>";
@@ -57,28 +57,28 @@ public class MutationReportTest {
 
     @Test
     public void countsKills() throws IOException, SAXException {
-        MutationReport report = MutationReport.create(mutationsXml);
+        MutationReport report = new MutationReport(mutationsXml);
         assertThat(report.getMutationStats().getKillCount(), is(5));
         assertThat(report.getMutationStats().getTotalMutations(), is(16));
     }
 
     @Test
     public void sortsMutationsByClassName() throws IOException, SAXException {
-        MutationReport report = MutationReport.create(mutationsXml);
+        MutationReport report = new MutationReport(mutationsXml);
         Collection<Mutation> mutations = report.getMutationsForClassName("org.jenkinsci.plugins.pitmutation.MutationReport");
         assertThat(mutations.size(), is(5));
     }
 
     @Test
     public void indexesMutationsByPackage() throws IOException, SAXException {
-        MutationReport report = MutationReport.create(mutationsXml);
+        MutationReport report = new MutationReport(mutationsXml);
         assertThat(report.getMutationsForPackage("org.jenkinsci.plugins.pitmutation"), hasSize(16));
         assertThat(report.getMutationsForPackage(""), hasSize(0));
     }
 
     @Test
     public void canDigestAMutation() throws IOException, SAXException {
-        MutationReport report = MutationReport.create(new ByteArrayInputStream(MUTATIONS.getBytes("UTF-8")));
+        MutationReport report = new MutationReport(new ByteArrayInputStream(MUTATIONS.getBytes("UTF-8")));
 
         assertThat(report.getMutationStats().getTotalMutations(), is(2));
 

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportTest.java
@@ -19,99 +19,143 @@ import static org.hamcrest.core.Is.is;
  */
 public class MutationReportTest {
 
-    private static final String MUTATIONS =
-        "<mutations>"
-            + "<mutation detected='true' status='NO_COVERAGE'>\n"
-            + "<sourceFile>SafeMultipartFile.java</sourceFile>\n"
-            + "<mutatedClass>com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile</mutatedClass>\n"
-            + "<mutatedMethod>getSize</mutatedMethod>\n"
-            + "<lineNumber>54</lineNumber>\n"
-            + "<mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>\n"
-            + "<indexes><index>5</index></indexes>\n"
-            + "<killingTest/>\n"
-            + "</mutation>"
-            + "<mutation detected='false' status='KILLED'>"
-            + "<sourceFile>SafeMultipartFile.java</sourceFile>"
-            + "<mutatedClass>com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile</mutatedClass>"
-            + "<mutatedMethod>getSize</mutatedMethod>"
-            + "<lineNumber>57</lineNumber>"
-            + "<mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>"
-            + "<indexes><index>6</index></indexes>"
-            + "<blocks><block>3</block></blocks>"
-            + "<killingTest/>"
-            + "</mutation>"
-            + "</mutations>";
+  private static final String MUTATIONS_OLD = "<mutations>"
+                                              + "<mutation detected='true' status='NO_COVERAGE'>\n"
+                                              + "<sourceFile>SafeMultipartFile.java</sourceFile>\n"
+                                              + "<mutatedClass>com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile</mutatedClass>\n"
+                                              + "<mutatedMethod>getSize</mutatedMethod>\n"
+                                              + "<lineNumber>54</lineNumber>\n"
+                                              + "<mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>\n"
+                                              + "<index>5</index>\n"
+                                              + "<killingTest/>\n"
+                                              + "</mutation>"
+                                              + "<mutation detected='false' status='KILLED'>"
+                                              + "<sourceFile>SafeMultipartFile.java</sourceFile>"
+                                              + "<mutatedClass>com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile</mutatedClass>"
+                                              + "<mutatedMethod>getSize</mutatedMethod>"
+                                              + "<lineNumber>57</lineNumber>"
+                                              + "<mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>"
+                                              + "<index>6</index>"
+                                              + "<block>3</block>"
+                                              + "<killingTest/>"
+                                              + "</mutation>"
+                                              + "</mutations>";
 
-    private InputStream mutationsXml;
+  private static final String MUTATIONS = "<mutations>"
+                                          + "<mutation detected='true' status='NO_COVERAGE'>\n"
+                                          + "<sourceFile>SafeMultipartFile.java</sourceFile>\n"
+                                          + "<mutatedClass>com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile</mutatedClass>\n"
+                                          + "<mutatedMethod>getSize</mutatedMethod>\n"
+                                          + "<lineNumber>54</lineNumber>\n"
+                                          + "<mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>\n"
+                                          + "<indexes><index>5</index></indexes>\n"
+                                          + "<killingTest/>\n"
+                                          + "</mutation>"
+                                          + "<mutation detected='false' status='KILLED'>"
+                                          + "<sourceFile>SafeMultipartFile.java</sourceFile>"
+                                          + "<mutatedClass>com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile</mutatedClass>"
+                                          + "<mutatedMethod>getSize</mutatedMethod>"
+                                          + "<lineNumber>57</lineNumber>"
+                                          + "<mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>"
+                                          + "<indexes><index>6</index></indexes>"
+                                          + "<blocks><block>3</block></blocks>"
+                                          + "<killingTest/>"
+                                          + "</mutation>"
+                                          + "</mutations>";
 
-    @Before
-    public void setUp() {
-        mutationsXml = getClass().getResourceAsStream("testmutations-00.xml");
+  private InputStream mutationsXml;
+
+  @Before
+  public void setUp() {
+    mutationsXml = getClass().getResourceAsStream("testmutations-00.xml");
+  }
+
+  @Test
+  public void packageNameFinder() {
+    assertThat(MutationReport.packageNameFromClass("xxx.yyy.zzz.Foo"), is("xxx.yyy.zzz"));
+    assertThat(MutationReport.packageNameFromClass("Foo"), is(""));
+  }
+
+  @Test
+  public void countsKills() throws IOException, SAXException {
+    MutationReport report = new MutationReport(mutationsXml);
+    assertThat(report.getMutationStats().getKillCount(), is(5));
+    assertThat(report.getMutationStats().getTotalMutations(), is(16));
+  }
+
+  @Test
+  public void sortsMutationsByClassName() throws IOException, SAXException {
+    MutationReport report = new MutationReport(mutationsXml);
+    Collection<Mutation> mutations =
+      report.getMutationsForClassName("org.jenkinsci.plugins.pitmutation.MutationReport");
+    assertThat(mutations.size(), is(5));
+  }
+
+  @Test
+  public void indexesMutationsByPackage() throws IOException, SAXException {
+    MutationReport report = new MutationReport(mutationsXml);
+    assertThat(report.getMutationsForPackage("org.jenkinsci.plugins.pitmutation"), hasSize(16));
+    assertThat(report.getMutationsForPackage(""), hasSize(0));
+  }
+
+  @Test
+  public void canDigestAMutation() throws IOException, SAXException {
+    MutationReport report = new MutationReport(new ByteArrayInputStream(MUTATIONS.getBytes("UTF-8")));
+
+    assertThat(report.getMutationStats().getTotalMutations(), is(2));
+
+    Iterator<Mutation> mutations =
+      report.getMutationsForClassName("com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile").iterator();
+
+    Mutation m1 = mutations.next();
+    Mutation m2 = mutations.next();
+
+    if (m1.getStatus().equals("KILLED")) {
+      verifyKilled(m1);
+      verifyNoCoverage(m2);
+    } else {
+      verifyKilled(m2);
+      verifyNoCoverage(m1);
     }
+  }
 
-    @Test
-    public void packageNameFinder() {
-        assertThat(MutationReport.packageNameFromClass("xxx.yyy.zzz.Foo"), is("xxx.yyy.zzz"));
-        assertThat(MutationReport.packageNameFromClass("Foo"), is(""));
+  @Test
+  public void canDigestAMutationOlderMutations() throws IOException, SAXException {
+    MutationReport report = new MutationReport(new ByteArrayInputStream(MUTATIONS_OLD.getBytes("UTF-8")));
+
+    assertThat(report.getMutationStats().getTotalMutations(), is(2));
+
+    Iterator<Mutation> mutations =
+      report.getMutationsForClassName("com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile").iterator();
+
+    Mutation m1 = mutations.next();
+    Mutation m2 = mutations.next();
+
+    if (m1.getStatus().equals("KILLED")) {
+      verifyKilled(m1);
+      verifyNoCoverage(m2);
+    } else {
+      verifyKilled(m2);
+      verifyNoCoverage(m1);
     }
+  }
 
-    @Test
-    public void countsKills() throws IOException, SAXException {
-        MutationReport report = new MutationReport(mutationsXml);
-        assertThat(report.getMutationStats().getKillCount(), is(5));
-        assertThat(report.getMutationStats().getTotalMutations(), is(16));
-    }
 
-    @Test
-    public void sortsMutationsByClassName() throws IOException, SAXException {
-        MutationReport report = new MutationReport(mutationsXml);
-        Collection<Mutation> mutations = report.getMutationsForClassName("org.jenkinsci.plugins.pitmutation.MutationReport");
-        assertThat(mutations.size(), is(5));
-    }
+  private void verifyNoCoverage(Mutation m) {
+    assertThat(m.getLineNumber(), is(54));
+    assertThat(m.isDetected(), is(true));
+    assertThat(m.getStatus(), is("NO_COVERAGE"));
+    assertThat(m.getSourceFile(), is("SafeMultipartFile.java"));
+    assertThat(m.getMutatedClass(), is("com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile"));
+    assertThat(m.getMutator(), is("org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator"));
+  }
 
-    @Test
-    public void indexesMutationsByPackage() throws IOException, SAXException {
-        MutationReport report = new MutationReport(mutationsXml);
-        assertThat(report.getMutationsForPackage("org.jenkinsci.plugins.pitmutation"), hasSize(16));
-        assertThat(report.getMutationsForPackage(""), hasSize(0));
-    }
-
-    @Test
-    public void canDigestAMutation() throws IOException, SAXException {
-        MutationReport report = new MutationReport(new ByteArrayInputStream(MUTATIONS.getBytes("UTF-8")));
-
-        assertThat(report.getMutationStats().getTotalMutations(), is(2));
-
-        Iterator<Mutation> mutations =
-            report.getMutationsForClassName("com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile").iterator();
-
-        Mutation m1 = mutations.next();
-        Mutation m2 = mutations.next();
-
-        if (m1.getStatus().equals("KILLED")) {
-            verifyKilled(m1);
-            verifyNoCoverage(m2);
-        } else {
-            verifyKilled(m2);
-            verifyNoCoverage(m1);
-        }
-    }
-
-    private void verifyNoCoverage(Mutation m) {
-        assertThat(m.getLineNumber(), is(54));
-        assertThat(m.isDetected(), is(true));
-        assertThat(m.getStatus(), is("NO_COVERAGE"));
-        assertThat(m.getSourceFile(), is("SafeMultipartFile.java"));
-        assertThat(m.getMutatedClass(), is("com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile"));
-        assertThat(m.getMutator(), is("org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator"));
-    }
-
-    private void verifyKilled(Mutation m) {
-        assertThat(m.getLineNumber(), is(57));
-        assertThat(m.isDetected(), is(false));
-        assertThat(m.getStatus(), is("KILLED"));
-        assertThat(m.getSourceFile(), is("SafeMultipartFile.java"));
-        assertThat(m.getMutatedClass(), is("com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile"));
-        assertThat(m.getMutator(), is("org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator"));
-    }
+  private void verifyKilled(Mutation m) {
+    assertThat(m.getLineNumber(), is(57));
+    assertThat(m.isDetected(), is(false));
+    assertThat(m.getStatus(), is("KILLED"));
+    assertThat(m.getSourceFile(), is("SafeMultipartFile.java"));
+    assertThat(m.getMutatedClass(), is("com.mediagraft.podsplice.controllers.massupload.SafeMultipartFile"));
+    assertThat(m.getMutator(), is("org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator"));
+  }
 }

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportWithDescriptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportWithDescriptionTest.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.pitmutation;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -16,37 +16,37 @@ import static org.hamcrest.core.Is.is;
 /**
  * @author edward
  */
-public class MutationReportWithDescriptionTest {
+class MutationReportWithDescriptionTest {
 
   private InputStream mutationsXml;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     mutationsXml = getClass().getResourceAsStream("testmutations-02.xml");
   }
 
   @Test
-  public void packageNameFinder() {
+  void packageNameFinder() {
     assertThat(MutationReport.packageNameFromClass("xxx.yyy.zzz.Foo"), is("xxx.yyy.zzz"));
     assertThat(MutationReport.packageNameFromClass("Foo"), is(""));
   }
 
   @Test
-  public void countsKills() throws IOException, SAXException {
+  void countsKills() throws IOException, SAXException {
     MutationReport report = new MutationReport(mutationsXml);
     assertThat(report.getMutationStats().getKillCount(), is(3));
     assertThat(report.getMutationStats().getTotalMutations(), is(4));
   }
 
   @Test
-  public void sortsMutationsByClassName() throws IOException, SAXException {
+  void sortsMutationsByClassName() throws IOException, SAXException {
     MutationReport report = new MutationReport(mutationsXml);
     Collection<Mutation> mutations = report.getMutationsForClassName("es.rodri.controllers.CompositorController");
     assertThat(mutations.size(), is(4));
   }
 
   @Test
-  public void indexesMutationsByPackage() throws IOException, SAXException {
+  void indexesMutationsByPackage() throws IOException, SAXException {
     MutationReport report = new MutationReport(mutationsXml);
     assertThat(report.getMutationsForPackage("es.rodri.controllers"), hasSize(4));
     assertThat(report.getMutationsForPackage(""), notNullValue());

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportWithDescriptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/MutationReportWithDescriptionTest.java
@@ -1,55 +1,55 @@
 package org.jenkinsci.plugins.pitmutation;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.core.Is.is;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.SAXException;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.xml.sax.SAXException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
 
 /**
  * @author edward
  */
 public class MutationReportWithDescriptionTest {
 
-    private InputStream mutationsXml;
+  private InputStream mutationsXml;
 
-    @Before
-    public void setUp() {
-        mutationsXml = getClass().getResourceAsStream("testmutations-02.xml");
-    }
+  @Before
+  public void setUp() {
+    mutationsXml = getClass().getResourceAsStream("testmutations-02.xml");
+  }
 
-    @Test
-    public void packageNameFinder() {
-        assertThat(MutationReport.packageNameFromClass("xxx.yyy.zzz.Foo"), is("xxx.yyy.zzz"));
-        assertThat(MutationReport.packageNameFromClass("Foo"), is(""));
-    }
+  @Test
+  public void packageNameFinder() {
+    assertThat(MutationReport.packageNameFromClass("xxx.yyy.zzz.Foo"), is("xxx.yyy.zzz"));
+    assertThat(MutationReport.packageNameFromClass("Foo"), is(""));
+  }
 
-    @Test
-    public void countsKills() throws IOException, SAXException {
-        MutationReport report = MutationReport.create(mutationsXml);
-        assertThat(report.getMutationStats().getKillCount(), is(3));
-        assertThat(report.getMutationStats().getTotalMutations(), is(4));
-    }
+  @Test
+  public void countsKills() throws IOException, SAXException {
+    MutationReport report = new MutationReport(mutationsXml);
+    assertThat(report.getMutationStats().getKillCount(), is(3));
+    assertThat(report.getMutationStats().getTotalMutations(), is(4));
+  }
 
-    @Test
-    public void sortsMutationsByClassName() throws IOException, SAXException {
-        MutationReport report = MutationReport.create(mutationsXml);
-        Collection<Mutation> mutations = report.getMutationsForClassName("es.rodri.controllers.CompositorController");
-        assertThat(mutations.size(), is(4));
-    }
+  @Test
+  public void sortsMutationsByClassName() throws IOException, SAXException {
+    MutationReport report = new MutationReport(mutationsXml);
+    Collection<Mutation> mutations = report.getMutationsForClassName("es.rodri.controllers.CompositorController");
+    assertThat(mutations.size(), is(4));
+  }
 
-    @Test
-    public void indexesMutationsByPackage() throws IOException, SAXException {
-        MutationReport report = MutationReport.create(mutationsXml);
-        assertThat(report.getMutationsForPackage("es.rodri.controllers"), hasSize(4));
-        assertThat(report.getMutationsForPackage(""), notNullValue());
-        assertThat(report.getMutationsForPackage(""), hasSize(0));
-    }
+  @Test
+  public void indexesMutationsByPackage() throws IOException, SAXException {
+    MutationReport report = new MutationReport(mutationsXml);
+    assertThat(report.getMutationsForPackage("es.rodri.controllers"), hasSize(4));
+    assertThat(report.getMutationsForPackage(""), notNullValue());
+    assertThat(report.getMutationsForPackage(""), hasSize(0));
+  }
 }

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/PercentageThresholdConditionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/PercentageThresholdConditionTest.java
@@ -1,0 +1,52 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.pitmutation.targets.MutationResult;
+import org.jenkinsci.plugins.pitmutation.targets.MutationStats;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.stream.Stream;
+
+import static hudson.model.Result.FAILURE;
+import static hudson.model.Result.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PercentageThresholdConditionTest {
+
+  @TestFactory
+  Stream<DynamicTest> testFactory() {
+    return Stream
+      .of(new TestCase(80f, 85f, SUCCESS, "killPercentGreaterThanThreshold"),
+          new TestCase(85f, 85f, SUCCESS, "killPercentEqualToThreshold"),
+          new TestCase(90f, 85f, FAILURE, "killPercentLessThanThreshold"))
+      .map(testCase -> dynamicTest(testCase.name, () -> {
+        PitBuildAction action = mock(PitBuildAction.class);
+        MutationResult report = mock(MutationResult.class);
+        MutationStats stats = mock(MutationStats.class);
+        when(action.getReport()).thenReturn(report);
+        when(report.getMutationStats()).thenReturn(stats);
+        when(stats.getKillPercent()).thenReturn(testCase.killPercent);
+
+        PercentageThresholdCondition condition = new PercentageThresholdCondition(testCase.threshold);
+        assertEquals(testCase.expectedResult, condition.decideResult(action));
+      }));
+  }
+
+  private static class TestCase {
+    float threshold;
+    float killPercent;
+    Result expectedResult;
+    String name;
+
+    TestCase(float threshold, float killPercent, Result expectedResult, String name) {
+      this.threshold = threshold;
+      this.killPercent = killPercent;
+      this.expectedResult = expectedResult;
+      this.name = name;
+    }
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/PitBuildActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/PitBuildActionTest.java
@@ -11,7 +11,8 @@ import java.io.File;
 import java.io.FilenameFilter;
 
 import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
@@ -19,13 +20,13 @@ import hudson.model.Result;
 /**
  * @author edward
  */
-public class PitBuildActionTest {
+class PitBuildActionTest {
     private PitBuildAction action;
     private AbstractBuild owner;
     private AbstractBuild failedBuild;
     private AbstractBuild successBuild;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         failedBuild = mock(AbstractBuild.class);
         when(failedBuild.getResult()).thenReturn(Result.FAILURE);
@@ -43,18 +44,18 @@ public class PitBuildActionTest {
     }
 
     @Test
-    public void previousReturnsNullIfNoPreviousBuilds() {
+    void previousReturnsNullIfNoPreviousBuilds() {
         assertThat(action.getPreviousAction(), nullValue());
     }
 
     @Test
-    public void previousReturnsNullIfAllPreviousBuildsFailed() {
+    void previousReturnsNullIfAllPreviousBuildsFailed() {
         when(owner.getPreviousBuild()).thenReturn(failedBuild);
         assertThat(action.getPreviousAction(), nullValue());
     }
 
     @Test
-    public void previousReturnsLastSuccessfulBuild() {
+    void previousReturnsLastSuccessfulBuild() {
         PitBuildAction previousSucccessAction = mock(PitBuildAction.class);
         when(owner.getPreviousBuild()).thenReturn(failedBuild);
         when(failedBuild.getPreviousBuild()).thenReturn(successBuild);

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/PitLoggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/PitLoggerTest.java
@@ -1,0 +1,83 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.FilePath;
+import hudson.model.TaskListener;
+import org.jenkinsci.plugins.pitmutation.targets.MutationResult;
+import org.jenkinsci.plugins.pitmutation.targets.MutationStats;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.io.PrintStream;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PitLoggerTest {
+
+  @Mock
+  private TaskListener listener;
+  @Mock
+  private PitBuildAction action;
+  @Mock
+  private MutationResult report;
+  @Mock
+  private MutationStats stats;
+  @Mock
+  private PrintStream printStream;
+
+  private PitLogger pitLogger;
+
+  @BeforeEach
+  void setUp() {
+    pitLogger = new PitLogger();
+
+    when(listener.getLogger()).thenReturn(printStream);
+  }
+
+  @Test
+  void logResults() {
+    when(action.getReport()).thenReturn(report);
+    when(action.getPreviousAction()).thenReturn(action);
+    when(report.getMutationStats()).thenReturn(stats);
+    when(stats.getKillPercent()).thenReturn(70.0f);
+
+    pitLogger.logResults(listener, action);
+
+    verify(printStream, atLeastOnce()).println(anyString());
+  }
+
+  @Test
+  void logMissingReportsIgnored() {
+    pitLogger.logMissingReportsIgnored(listener);
+    verify(printStream).println(anyString());
+  }
+
+  @Test
+  void logBuildFailedNoReports() {
+    pitLogger.logBuildFailedNoReports(listener);
+    verify(printStream).println(anyString());
+  }
+
+  @Test
+  void logLookingForReports() {
+    FilePath workspace = new FilePath(new File("path/to/workspace"));
+    pitLogger.logLookingForReports(listener, workspace);
+
+    verify(printStream).println(anyString());
+  }
+
+  @Test
+  void logPublishReport() {
+    FilePath workspace = new FilePath(new File("path/to/workspace"));
+    pitLogger.logPublishReport(listener, workspace);
+
+    verify(printStream).println(anyString());
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/PitProjectActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/PitProjectActionTest.java
@@ -1,0 +1,126 @@
+package org.jenkinsci.plugins.pitmutation;
+
+
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static hudson.model.Result.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class PitProjectActionTest {
+
+  @Mock
+  private AbstractProject<?, ?> project;
+  @Mock
+  private AbstractBuild<?, ?> lastSuccessfulBuild;
+  @Mock
+  private AbstractBuild<?, ?> previousSuccessfulBuild;
+  @Mock
+  private AbstractBuild<?, ?> failedBuild;
+  @Mock
+  private PitBuildAction action;
+  @Mock
+  private StaplerRequest req;
+  @Mock
+  private StaplerResponse rsp;
+
+  private PitProjectAction pitProjectAction;
+
+  @BeforeEach
+  void setUp() {
+    pitProjectAction = new PitProjectAction(project);
+  }
+
+  @Test
+  void getLastResult_noLastResult() {
+    doReturn(null).when(project).getLastSuccessfulBuild();
+    PitBuildAction lastResult = pitProjectAction.getLastResult();
+    assertNull(lastResult);
+  }
+
+  @Test
+  void getLastResult_returnsLastResult() {
+    doReturn(lastSuccessfulBuild).when(project).getLastSuccessfulBuild();
+    doReturn(SUCCESS).when(lastSuccessfulBuild).getResult();
+    doReturn(action).when(lastSuccessfulBuild).getAction(PitBuildAction.class);
+
+    PitBuildAction lastResult = pitProjectAction.getLastResult();
+    assertEquals(action, lastResult);
+  }
+
+  @Test
+  void getLastResultBuild_returnsLastBuildNumber() {
+    doReturn(lastSuccessfulBuild).when(project).getLastSuccessfulBuild();
+    doReturn(action).when(lastSuccessfulBuild).getAction(PitBuildAction.class);
+    doReturn(10).when(lastSuccessfulBuild).getNumber();
+
+    Integer lastResultBuild = pitProjectAction.getLastResultBuild();
+    assertEquals(10, lastResultBuild);
+  }
+
+  @Test
+  void getIconFileName_returnsCorrectPath() {
+    String iconPath = pitProjectAction.getIconFileName();
+    assertEquals("/plugin/pitmutation/pitest.png", iconPath);
+  }
+
+  @Test
+  void getDisplayName_returnsCorrectName() {
+    String name = pitProjectAction.getDisplayName();
+    assertEquals("PIT Mutation Report", name);
+  }
+
+  @Test
+  void getSearchUrl_returnsCorrectUrl() {
+    String url = pitProjectAction.getSearchUrl();
+    assertEquals("pitmutation", url);
+  }
+
+  @Test
+  void isFloatingBoxActive_returnsTrue() {
+    assertTrue(pitProjectAction.isFloatingBoxActive());
+  }
+
+  @Test
+  void doIndex_redirectsCorrectly() throws IOException {
+    doReturn(lastSuccessfulBuild).when(project).getLastSuccessfulBuild();
+    doReturn(action).when(lastSuccessfulBuild).getAction(PitBuildAction.class);
+    doReturn(10).when(lastSuccessfulBuild).getNumber();
+
+    pitProjectAction.doIndex(req, rsp);
+
+    verify(rsp).sendRedirect2("../10/pitmutation");
+  }
+
+  @Test
+  void doIndex_buildNumberNull_redirectsCorrectly() throws IOException {
+    doReturn(null).when(project).getLastSuccessfulBuild();
+    pitProjectAction.doIndex(req, rsp);
+    verify(rsp).sendRedirect2("nodata");
+  }
+
+  @Test
+  void doGraph_CallsDoGraphOnLastResult() throws IOException {
+    doReturn(lastSuccessfulBuild).when(project).getLastSuccessfulBuild();
+    doReturn(action).when(lastSuccessfulBuild).getAction(PitBuildAction.class);
+
+    pitProjectAction.doGraph(req, rsp);
+
+    verify(action).doGraph(req, rsp);
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/PitPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/PitPublisherTest.java
@@ -34,8 +34,8 @@ public class PitPublisherTest {
         boolean infoImproveLogged = false;
         boolean infoPercentLogged = false;
 
-        public PitPublisherTSS(String mutationStatsFile, float minimumKillRatio, boolean killRatioMustImprove) {
-            super(mutationStatsFile, minimumKillRatio, killRatioMustImprove);
+        public PitPublisherTSS(String mutationStatsFile, float minimumKillRatio, boolean killRatioMustImprove, boolean ignoreMissingReports) {
+            super(mutationStatsFile, minimumKillRatio, killRatioMustImprove, ignoreMissingReports);
         }
 
         class MustImproveConditionTSS extends MustImproveCondition {
@@ -126,7 +126,7 @@ public class PitPublisherTest {
     }
 
     private PitPublisherTSS createPitPublisher(boolean mustImprove) {
-        return new PitPublisherTSS("**/mutations.xml", MINIMUM_KILL_RATIO, mustImprove);
+        return new PitPublisherTSS("**/mutations.xml", MINIMUM_KILL_RATIO, mustImprove, false);
     }
 
     private void setupBoilderPlateMocks() {

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/PitPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/PitPublisherTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/PitPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/PitPublisherTest.java
@@ -80,9 +80,10 @@ class PitPublisherTest {
       new PitPublisher("**/mutations.xml", MINIMUM_KILL_RATIO, true, false, fileProcessor, decider, pitLogger);
     TaskListener taskListener = mock(TaskListener.class);
     Run<?, ?> build = mock(Run.class);
+    FilePath workspace = mock(FilePath.class);
+    when(workspace.act(any(FilePath.FileCallable.class))).thenReturn(new FilePath[]{mock(FilePath.class), mock(FilePath.class)});
 
-
-    publisher.perform(build, mock(FilePath.class), mock(EnvVars.class), mock(Launcher.class), taskListener);
+    publisher.perform(build, workspace, mock(EnvVars.class), mock(Launcher.class), taskListener);
 
     verify(build).setResult(FAILURE);
     verify(pitLogger).logBuildFailedNoReports(any());
@@ -102,7 +103,10 @@ class PitPublisherTest {
       pitLogger);
     TaskListener taskListener = mock(TaskListener.class);
     FilePath workspace = mock(FilePath.class);
-    FilePath[] reports = {mock(FilePath.class)};
+    FilePath report = mock(FilePath.class);
+    when(report.exists()).thenReturn(true);
+    when(report.isDirectory()).thenReturn(false);
+    FilePath[] reports = {report};
     when(workspace.act(any(ParseReportCallable.class))).thenReturn(reports);
     doThrow(IOException.class).when(fileProcessor).copySingleModuleReport(any(), any());
     Run<?, ?> build = mock(Run.class);
@@ -127,7 +131,10 @@ class PitPublisherTest {
       pitLogger);
     TaskListener taskListener = mock(TaskListener.class);
     FilePath workspace = mock(FilePath.class);
-    FilePath[] reports = {mock(FilePath.class)};
+    FilePath report = mock(FilePath.class);
+    when(report.exists()).thenReturn(true);
+    when(report.isDirectory()).thenReturn(false);
+    FilePath[] reports = {report};
     when(workspace.act(any(ParseReportCallable.class))).thenReturn(reports);
     doNothing().when(fileProcessor).copySingleModuleReport(any(), any());
     Run<?, ?> build = mock(Run.class);
@@ -154,7 +161,14 @@ class PitPublisherTest {
       pitLogger);
     TaskListener taskListener = mock(TaskListener.class);
     FilePath workspace = mock(FilePath.class);
-    FilePath[] reports = {mock(FilePath.class), mock(FilePath.class)};
+    FilePath report1 = mock(FilePath.class);
+    when(report1.exists()).thenReturn(true);
+    when(report1.isDirectory()).thenReturn(false);
+    FilePath report2 = mock(FilePath.class);
+    when(report2.exists()).thenReturn(true);
+    when(report2.isDirectory()).thenReturn(false);
+
+    FilePath[] reports = {report1, report2};
     when(workspace.act(any(ParseReportCallable.class))).thenReturn(reports);
     when(fileProcessor.getNames(any(), any())).thenReturn(Map.of(mock(FilePath.class),
                                                                    "1",
@@ -185,7 +199,15 @@ class PitPublisherTest {
       pitLogger);
     TaskListener taskListener = mock(TaskListener.class);
     FilePath workspace = mock(FilePath.class);
-    FilePath[] reports = {mock(FilePath.class), mock(FilePath.class)};
+    FilePath report1 = mock(FilePath.class);
+    when(report1.exists()).thenReturn(true);
+    when(report1.isDirectory()).thenReturn(false);
+
+    FilePath report2 = mock(FilePath.class);
+    when(report2.exists()).thenReturn(true);
+    when(report2.isDirectory()).thenReturn(false);
+
+    FilePath[] reports = {report1, report2};
     when(workspace.act(any(ParseReportCallable.class))).thenReturn(reports);
     when(fileProcessor.getNames(any(), any())).thenReturn(Map.of(mock(FilePath.class),
                                                                  "1",

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/ResultDeciderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/ResultDeciderTest.java
@@ -1,0 +1,46 @@
+package org.jenkinsci.plugins.pitmutation;
+
+import hudson.model.Result;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static hudson.model.Result.FAILURE;
+import static hudson.model.Result.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ResultDeciderTest {
+
+  @TestFactory
+  Stream<DynamicTest> testFactory() {
+    // Create a collection of inputs for the test.
+    Collection<Object[]> inputs = Arrays.asList(new Object[][] {
+      {SUCCESS, SUCCESS, SUCCESS},
+      {FAILURE, SUCCESS, FAILURE},
+      {SUCCESS, FAILURE, FAILURE},
+      {FAILURE, FAILURE, FAILURE}
+    });
+
+    // Create and return the dynamic tests.
+    return inputs.stream().map(input -> DynamicTest.dynamicTest(
+      "Testing with thresholdResult = " + input[0] + ", mustImproveResult = " + input[1],
+      () -> runTest((Result) input[0], (Result) input[1], (Result) input[2])
+                                                               ));
+  }
+
+  private void runTest(Result thresholdResult, Result mustImproveResult, Result expectedResult) {
+    PercentageThresholdCondition thresholdCondition = mock(PercentageThresholdCondition.class);
+    MustImproveCondition mustImproveCondition = mock(MustImproveCondition.class);
+    PitBuildAction action = mock(PitBuildAction.class);
+    when(thresholdCondition.decideResult(action)).thenReturn(thresholdResult);
+    when(mustImproveCondition.decideResult(action)).thenReturn(mustImproveResult);
+    ResultDecider decider = new ResultDecider(thresholdCondition, mustImproveCondition);
+    Result result = decider.decideBuildResult(action);
+    assertEquals(expectedResult, result);
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/portlets/CoverageRangeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/portlets/CoverageRangeTest.java
@@ -1,179 +1,188 @@
 package org.jenkinsci.plugins.pitmutation.portlets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import java.awt.*;
+
+import java.awt.Color;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.*;
+import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.ABYSMAL;
+import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.AVERAGE;
+import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.EXCELLENT;
+import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.FAIR;
+import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.GOOD;
+import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.PERFECT;
+import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.POOR;
+import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.SUFFICIENT;
+import static org.jenkinsci.plugins.pitmutation.portlets.CoverageRange.TRAGIC;
 
-public class CoverageRangeTest {
+class CoverageRangeTest {
 
-    @Test
-    public void valueOfLessTHanZeroReturnsAbysmal() {
-        assertThat(CoverageRange.valueOf(-1D), is(ABYSMAL));
-    }
+  @Test
+  void valueOfLessTHanZeroReturnsAbysmal() {
+    assertThat(CoverageRange.valueOf(-1D), is(ABYSMAL));
+  }
 
-    @Test
-    public void valueOfZeroReturnsAbysmal() {
-        assertThat(CoverageRange.valueOf(0D), is(ABYSMAL));
-    }
+  @Test
+  void valueOfZeroReturnsAbysmal() {
+    assertThat(CoverageRange.valueOf(0D), is(ABYSMAL));
+  }
 
-    @Test
-    public void valueOfTwentyFiveReturnsTragic() {
-        assertThat(CoverageRange.valueOf(25D), is(TRAGIC));
-    }
+  @Test
+  void valueOfTwentyFiveReturnsTragic() {
+    assertThat(CoverageRange.valueOf(25D), is(TRAGIC));
+  }
 
-    @Test
-    public void valueOfFiftyReturnsPoor() {
-        assertThat(CoverageRange.valueOf(50D), is(AVERAGE));
-    }
+  @Test
+  void valueOfFiftyReturnsPoor() {
+    assertThat(CoverageRange.valueOf(50D), is(AVERAGE));
+  }
 
-    @Test
-    public void valueOfSeventyFiveReturnsFair() {
-        assertThat(CoverageRange.valueOf(75D), is(SUFFICIENT));
-    }
+  @Test
+  void valueOfSeventyFiveReturnsFair() {
+    assertThat(CoverageRange.valueOf(75D), is(SUFFICIENT));
+  }
 
-    @Test
-    public void valueOfEightyFiveReturnsSufficient() {
-        assertThat(CoverageRange.valueOf(85D), is(GOOD));
-    }
+  @Test
+  void valueOfEightyFiveReturnsSufficient() {
+    assertThat(CoverageRange.valueOf(85D), is(GOOD));
+  }
 
-    @Test
-    public void valueOfNinetyTwoReturnsGood() {
-        assertThat(CoverageRange.valueOf(92D), is(EXCELLENT));
-    }
+  @Test
+  void valueOfNinetyTwoReturnsGood() {
+    assertThat(CoverageRange.valueOf(92D), is(EXCELLENT));
+  }
 
-    @Test
-    public void valueOfNinetySevenReturnsExcellent() {
-        assertThat(CoverageRange.valueOf(97D), is(EXCELLENT));
-    }
+  @Test
+  void valueOfNinetySevenReturnsExcellent() {
+    assertThat(CoverageRange.valueOf(97D), is(EXCELLENT));
+  }
 
-    @Test
-    public void valueOfOneHundredReturnsPerfect() {
-        assertThat(CoverageRange.valueOf(100D), is(PERFECT));
-    }
+  @Test
+  void valueOfOneHundredReturnsPerfect() {
+    assertThat(CoverageRange.valueOf(100D), is(PERFECT));
+  }
 
-    @Test
-    public void valueOfOneHundredAndOneReturnsPerfect() {
-        assertThat(CoverageRange.valueOf(101D), is(PERFECT));
-    }
+  @Test
+  void valueOfOneHundredAndOneReturnsPerfect() {
+    assertThat(CoverageRange.valueOf(101D), is(PERFECT));
+  }
 
-    @Test
-    public void getFillHexStringForAbysmal() {
-        assertThat(ABYSMAL.getFillHexString(), is("FF0000"));
-    }
+  @Test
+  void getFillHexStringForAbysmal() {
+    assertThat(ABYSMAL.getFillHexString(), is("FF0000"));
+  }
 
-    @Test
-    public void getFillHexStringForTragic() {
-        assertThat(TRAGIC.getFillHexString(), is("FF4500"));
-    }
+  @Test
+  void getFillHexStringForTragic() {
+    assertThat(TRAGIC.getFillHexString(), is("FF4500"));
+  }
 
-    @Test
-    public void getFillHexStringForPoor() {
-        assertThat(POOR.getFillHexString(), is("FF7F00"));
-    }
+  @Test
+  void getFillHexStringForPoor() {
+    assertThat(POOR.getFillHexString(), is("FF7F00"));
+  }
 
-    @Test
-    public void getFillHexStringForFair() {
-        assertThat(FAIR.getFillHexString(), is("FFFF00"));
-    }
+  @Test
+  void getFillHexStringForFair() {
+    assertThat(FAIR.getFillHexString(), is("FFFF00"));
+  }
 
-    @Test
-    public void getFillHexStringForSufficient() {
-        assertThat(SUFFICIENT.getFillHexString(), is("C8FF3F"));
-    }
+  @Test
+  void getFillHexStringForSufficient() {
+    assertThat(SUFFICIENT.getFillHexString(), is("C8FF3F"));
+  }
 
-    @Test
-    public void getFillHexStringForGood() {
-        assertThat(GOOD.getFillHexString(), is("7AFF3F"));
-    }
+  @Test
+  void getFillHexStringForGood() {
+    assertThat(GOOD.getFillHexString(), is("7AFF3F"));
+  }
 
-    @Test
-    public void getFillHexStringForExcellent() {
-        assertThat(EXCELLENT.getFillHexString(), is("00CD00"));
-    }
+  @Test
+  void getFillHexStringForExcellent() {
+    assertThat(EXCELLENT.getFillHexString(), is("00CD00"));
+  }
 
-    @Test
-    public void getFillHexStringForPerfect() {
-        assertThat(PERFECT.getFillHexString(), is("008B00"));
-    }
+  @Test
+  void getFillHexStringForPerfect() {
+    assertThat(PERFECT.getFillHexString(), is("008B00"));
+  }
 
-    @Test
-    public void getLineHexStringForAbysmal() {
-        assertThat(ABYSMAL.getLineHexString(), is("EEEEEE"));
-    }
+  @Test
+  void getLineHexStringForAbysmal() {
+    assertThat(ABYSMAL.getLineHexString(), is("EEEEEE"));
+  }
 
-    @Test
-    public void getLineHexStringForTragic() {
-        assertThat(TRAGIC.getLineHexString(), is("EEEEEE"));
-    }
+  @Test
+  void getLineHexStringForTragic() {
+    assertThat(TRAGIC.getLineHexString(), is("EEEEEE"));
+  }
 
-    @Test
-    public void getLineHexStringForPoor() {
-        assertThat(POOR.getLineHexString(), is("000000"));
-    }
+  @Test
+  void getLineHexStringForPoor() {
+    assertThat(POOR.getLineHexString(), is("000000"));
+  }
 
-    @Test
-    public void getLineHexStringForFair() {
-        assertThat(FAIR.getLineHexString(), is("000000"));
-    }
+  @Test
+  void getLineHexStringForFair() {
+    assertThat(FAIR.getLineHexString(), is("000000"));
+  }
 
-    @Test
-    public void getLineHexStringForSufficient() {
-        assertThat(SUFFICIENT.getLineHexString(), is("000000"));
-    }
+  @Test
+  void getLineHexStringForSufficient() {
+    assertThat(SUFFICIENT.getLineHexString(), is("000000"));
+  }
 
-    @Test
-    public void getLineHexStringForGood() {
-        assertThat(GOOD.getLineHexString(), is("000000"));
-    }
+  @Test
+  void getLineHexStringForGood() {
+    assertThat(GOOD.getLineHexString(), is("000000"));
+  }
 
-    @Test
-    public void getLineHexStringForExcellent() {
-        assertThat(EXCELLENT.getLineHexString(), is("000000"));
-    }
+  @Test
+  void getLineHexStringForExcellent() {
+    assertThat(EXCELLENT.getLineHexString(), is("000000"));
+  }
 
-    @Test
-    public void getLineHexStringForPerfect() {
-        assertThat(PERFECT.getLineHexString(), is("EEEEEE"));
-    }
+  @Test
+  void getLineHexStringForPerfect() {
+    assertThat(PERFECT.getLineHexString(), is("EEEEEE"));
+  }
 
-    @Test
-    public void fillColorOfMinusOneReturnsAbysmalFloor() {
-        assertThat(CoverageRange.fillColorOf(-1D), is(new Color(255, 0, 0)));
-    }
+  @Test
+  void fillColorOfMinusOneReturnsAbysmalFloor() {
+    assertThat(CoverageRange.fillColorOf(-1D), is(new Color(255, 0, 0)));
+  }
 
-    @Test
-    public void fillColorOfThirtyReturnsProportionateBlend() {
-        assertThat(CoverageRange.fillColorOf(30D), is(new Color(255, 88, 0)));
-    }
+  @Test
+  void fillColorOfThirtyReturnsProportionateBlend() {
+    assertThat(CoverageRange.fillColorOf(30D), is(new Color(255, 88, 0)));
+  }
 
-    @Test
-    public void fillColorOfThirtySevenFiveReturnsProportionateBlend() {
-        assertThat(CoverageRange.fillColorOf(37.5), is(new Color(255, 117, 0)));
-    }
+  @Test
+  void fillColorOfThirtySevenFiveReturnsProportionateBlend() {
+    assertThat(CoverageRange.fillColorOf(37.5), is(new Color(255, 117, 0)));
+  }
 
-    @Test
-    public void fillColorOfFortyFiveReturnsProportionateBlend() {
-        assertThat(CoverageRange.fillColorOf(45D), is(new Color(255, 146, 0)));
-    }
+  @Test
+  void fillColorOfFortyFiveReturnsProportionateBlend() {
+    assertThat(CoverageRange.fillColorOf(45D), is(new Color(255, 146, 0)));
+  }
 
-    @Test
-    public void fillColorOfFiftyFloorFillColor() {
-        assertThat(CoverageRange.fillColorOf(50D), is(new Color(255, 165, 0)));
-    }
+  @Test
+  void fillColorOfFiftyFloorFillColor() {
+    assertThat(CoverageRange.fillColorOf(50D), is(new Color(255, 165, 0)));
+  }
 
-    @Test
-    public void fillColorOfOneHundredAndOneReturnsPerfectFloor() {
-        assertThat(CoverageRange.fillColorOf(101D), is(new Color(0, 139, 0)));
-    }
+  @Test
+  void fillColorOfOneHundredAndOneReturnsPerfectFloor() {
+    assertThat(CoverageRange.fillColorOf(101D), is(new Color(0, 139, 0)));
+  }
 
-    @Test
-    public void colorAsHexString() {
-        Color color = new Color(0, 128, 255);
-        assertThat(CoverageRange.colorAsHexString(color), is("0080FF"));
-    }
+  @Test
+  void colorAsHexString() {
+    Color color = new Color(0, 128, 255);
+    assertThat(CoverageRange.colorAsHexString(color), is("0080FF"));
+  }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutatedClassTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutatedClassTest.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.pitmutation.targets;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -15,27 +15,27 @@ import static org.hamcrest.Matchers.is;
  * Date: 19/03/13
  * Time: 18:45
  */
-public class MutatedClassTest extends MutationResultTest {
+class MutatedClassTest extends MutationResultTest {
 
     private MutatedClass mutatedClass;
 
-    @Before
+    @BeforeEach
     public void setUp() throws IOException, SAXException {
         super.setUp();
         mutatedClass = new MutatedClass("TestClass", null, new ArrayList<>());
     }
 
     @Test
-    public void isSourceLevelReturnsTrue() {
+    void isSourceLevelReturnsTrue() {
         assertThat(mutatedClass.isSourceLevel(), is(true));
     }
 
     @Test
-    public void getDisplayNameReturnsName() {
+    void getDisplayNameReturnsName() {
         assertThat(mutatedClass.getDisplayName(), is("Class: TestClass"));
     }
 
     @Test
-    public void lineUrlsAreSet() {
+    void lineUrlsAreSet() {
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutatedLineTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutatedLineTest.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.pitmutation.targets;
 
 import org.jenkinsci.plugins.pitmutation.Mutation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -14,10 +14,10 @@ import static org.mockito.Mockito.when;
 /**
  * @author Ed Kimber
  */
-public class MutatedLineTest {
+class MutatedLineTest {
 
     @Test
-    public void getsMutatorClassNames() {
+    void getsMutatorClassNames() {
         Mutation[] mutations = new Mutation[3];
 
         mutations[0] = mock(Mutation.class);

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutationResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutationResultTest.java
@@ -2,8 +2,8 @@ package org.jenkinsci.plugins.pitmutation.targets;
 
 import org.jenkinsci.plugins.pitmutation.MutationReport;
 import org.jenkinsci.plugins.pitmutation.PitBuildAction;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -28,7 +28,7 @@ public abstract class MutationResultTest {
   private MutationResult<?> projectResult;
   private MutationResult<?> moduleResult;
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException, SAXException {
     MutationReport reportOld =
       new MutationReport(MutationReport.class.getResourceAsStream("testmutations-00.xml"));
@@ -55,7 +55,7 @@ public abstract class MutationResultTest {
   }
 
   @Test
-  public void mutationResultStatsDelta() {
+  void mutationResultStatsDelta() {
     MutationStats delta = projectResult.getStatsDelta();
     assertThat(delta.getTotalMutations(), is(3));
     assertThat(delta.getKillCount(), is(-1));
@@ -66,7 +66,7 @@ public abstract class MutationResultTest {
   }
 
   @Test
-  public void packageResultsStatsDelta() {
+  void packageResultsStatsDelta() {
     MutationStats delta = packageResult().getStatsDelta();
     assertThat(delta.getTotalMutations(), is(3));
     assertThat(delta.getKillCount(), is(-1));
@@ -77,35 +77,35 @@ public abstract class MutationResultTest {
   }
 
   @Test
-  public void classResultsStats() {
+  void classResultsStats() {
     MutationStats stats = classResult("org.jenkinsci.plugins.pitmutation.Mutation").getMutationStats();
     assertThat(stats.getTotalMutations(), is(3));
     assertThat(stats.getKillCount(), is(1));
   }
 
   @Test
-  public void classResultsStatsDelta() {
+  void classResultsStatsDelta() {
     MutationStats delta = classResult("org.jenkinsci.plugins.pitmutation.Mutation").getStatsDelta();
     assertThat(delta.getTotalMutations(), is(-1));
     assertThat(delta.getKillCount(), is(-2));
   }
 
   @Test
-  public void classResultsForNewClass() {
+  void classResultsForNewClass() {
     MutationStats stats = classResult("org.jenkinsci.plugins.pitmutation.NewMutatedClass").getMutationStats();
     assertThat(stats.getTotalMutations(), is(1));
     assertThat(stats.getKillCount(), is(0));
   }
 
   @Test
-  public void classResultsForNewClassDelta() {
+  void classResultsForNewClassDelta() {
     MutationStats stats = classResult("org.jenkinsci.plugins.pitmutation.NewMutatedClass").getStatsDelta();
     assertThat(stats.getTotalMutations(), is(1));
     assertThat(stats.getKillCount(), is(0));
   }
 
   @Test
-  public void classResultsOrdered() {
+  void classResultsOrdered() {
     Iterator<? extends MutationResult> classes = moduleResult.getChildren().iterator();
     int undetected = classes.next().getMutationStats().getUndetected();
 
@@ -117,13 +117,13 @@ public abstract class MutationResultTest {
   }
 
   @Test
-  public void urlTransformPackageName() {
+  void urlTransformPackageName() {
     assertThat(moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation").getUrl(),
                is("org_jenkinsci_plugins_pitmutation"));
   }
 
   @Test
-  public void urlTransformClassName() {
+  void urlTransformClassName() {
     assertThat(moduleResult
                  .getChildMap()
                  .get("org.jenkinsci.plugins.pitmutation")
@@ -133,7 +133,7 @@ public abstract class MutationResultTest {
   }
 
   @Test
-  public void findsMutationsOnPitParserClass() {
+  void findsMutationsOnPitParserClass() {
     MutationResult<?> pitPackage = moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation");
     assertThat(pitPackage.getChildren(), hasSize(5));
     MutationResult<?> pitParser = pitPackage.getChildMap().get("org.jenkinsci.plugins.pitmutation.PitParser");
@@ -141,14 +141,14 @@ public abstract class MutationResultTest {
   }
 
   @Test
-  public void collectsMutationStats() {
+  void collectsMutationStats() {
     MutationStats stats = projectResult.getMutationStats();
     assertThat(stats.getTotalMutations(), is(19));
     assertThat(stats.getUndetected(), is(15));
   }
 
   @Test
-  public void correctSourceLevels() {
+  void correctSourceLevels() {
     MutationResult<?> pitPackage = moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation");
     MutationResult<?> pitParser = pitPackage.getChildMap().get("org.jenkinsci.plugins.pitmutation.PitParser");
     MutationResult<?> lineResult = pitParser.getChildMap().values().iterator().next();
@@ -161,12 +161,12 @@ public abstract class MutationResultTest {
   }
 
   @Test
-  public void testXmlTransform() {
+  void testXmlTransform() {
     assertThat(MutationResult.xmlTransform("replace&and<and>"), is("replace&amp;and&lt;and&gt;"));
   }
 
   @Test
-  public void testUrlTransform() {
+  void testUrlTransform() {
     assertThat(MutationResult.urlTransform("^*!replace::non+'alphas@}129"), is("___replace__non__alphas__129"));
   }
 }

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutationResultTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutationResultTest.java
@@ -12,7 +12,11 @@ import java.util.Iterator;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,143 +25,148 @@ import static org.mockito.Mockito.when;
  */
 public abstract class MutationResultTest {
 
-    private MutationResult<?> projectResult;
-    private MutationResult<?> moduleResult;
+  private MutationResult<?> projectResult;
+  private MutationResult<?> moduleResult;
 
-    @Before
-    public void setUp() throws IOException, SAXException {
-        MutationReport reportOld = MutationReport.create(MutationReport.class.getResourceAsStream("testmutations-00.xml"));
-        MutationReport reportNew = MutationReport.create(MutationReport.class.getResourceAsStream("testmutations-01.xml"));
-        Map<String, MutationReport> reportsNew = new HashMap<>();
-        Map<String, MutationReport> reportsOld = new HashMap<>();
-        reportsNew.put("test_report", reportNew);
-        reportsOld.put("test_report", reportOld);
+  @Before
+  public void setUp() throws IOException, SAXException {
+    MutationReport reportOld =
+      new MutationReport(MutationReport.class.getResourceAsStream("testmutations-00.xml"));
+    MutationReport reportNew =
+      new MutationReport(MutationReport.class.getResourceAsStream("testmutations-01.xml"));
+    Map<String, MutationReport> reportsNew = new HashMap<>();
+    Map<String, MutationReport> reportsOld = new HashMap<>();
+    reportsNew.put("test_report", reportNew);
+    reportsOld.put("test_report", reportOld);
 
-        PitBuildAction buildAction = mock(PitBuildAction.class);
-        when(buildAction.getReports()).thenReturn(reportsNew);
+    PitBuildAction buildAction = mock(PitBuildAction.class);
+    when(buildAction.getReports()).thenReturn(reportsNew);
 
-        PitBuildAction previousBuildAction = mock(PitBuildAction.class);
-        when(previousBuildAction.getReports()).thenReturn(reportsOld);
-        when(previousBuildAction.getReport()).thenReturn(new ProjectMutations(previousBuildAction));
+    PitBuildAction previousBuildAction = mock(PitBuildAction.class);
+    when(previousBuildAction.getReports()).thenReturn(reportsOld);
+    when(previousBuildAction.getReport()).thenReturn(new ProjectMutations(previousBuildAction));
 
-        when(buildAction.getPreviousAction()).thenReturn(previousBuildAction);
+    when(buildAction.getPreviousAction()).thenReturn(previousBuildAction);
 
-        projectResult = new ProjectMutations(buildAction);
-        moduleResult = projectResult.getChildMap().get("test_report");
-        assertThat(moduleResult, not(nullValue()));
-        assertThat(projectResult.getPreviousResult(), not(nullValue()));
+    projectResult = new ProjectMutations(buildAction);
+    moduleResult = projectResult.getChildMap().get("test_report");
+    assertThat(moduleResult, not(nullValue()));
+    assertThat(projectResult.getPreviousResult(), not(nullValue()));
+  }
+
+  @Test
+  public void mutationResultStatsDelta() {
+    MutationStats delta = projectResult.getStatsDelta();
+    assertThat(delta.getTotalMutations(), is(3));
+    assertThat(delta.getKillCount(), is(-1));
+  }
+
+  private MutationResult packageResult() {
+    return projectResult.getChildResult("test_report").getChildResult("org.jenkinsci.plugins.pitmutation");
+  }
+
+  @Test
+  public void packageResultsStatsDelta() {
+    MutationStats delta = packageResult().getStatsDelta();
+    assertThat(delta.getTotalMutations(), is(3));
+    assertThat(delta.getKillCount(), is(-1));
+  }
+
+  private MutationResult classResult(String className) {
+    return packageResult().getChildResult(className);
+  }
+
+  @Test
+  public void classResultsStats() {
+    MutationStats stats = classResult("org.jenkinsci.plugins.pitmutation.Mutation").getMutationStats();
+    assertThat(stats.getTotalMutations(), is(3));
+    assertThat(stats.getKillCount(), is(1));
+  }
+
+  @Test
+  public void classResultsStatsDelta() {
+    MutationStats delta = classResult("org.jenkinsci.plugins.pitmutation.Mutation").getStatsDelta();
+    assertThat(delta.getTotalMutations(), is(-1));
+    assertThat(delta.getKillCount(), is(-2));
+  }
+
+  @Test
+  public void classResultsForNewClass() {
+    MutationStats stats = classResult("org.jenkinsci.plugins.pitmutation.NewMutatedClass").getMutationStats();
+    assertThat(stats.getTotalMutations(), is(1));
+    assertThat(stats.getKillCount(), is(0));
+  }
+
+  @Test
+  public void classResultsForNewClassDelta() {
+    MutationStats stats = classResult("org.jenkinsci.plugins.pitmutation.NewMutatedClass").getStatsDelta();
+    assertThat(stats.getTotalMutations(), is(1));
+    assertThat(stats.getKillCount(), is(0));
+  }
+
+  @Test
+  public void classResultsOrdered() {
+    Iterator<? extends MutationResult> classes = moduleResult.getChildren().iterator();
+    int undetected = classes.next().getMutationStats().getUndetected();
+
+    while (classes.hasNext()) {
+      MutationResult result = classes.next();
+      assertThat(result.getMutationStats().getUndetected(), lessThan(undetected));
+      undetected = result.getMutationStats().getUndetected();
     }
+  }
 
-    @Test
-    public void mutationResultStatsDelta() {
-        MutationStats delta = projectResult.getStatsDelta();
-        assertThat(delta.getTotalMutations(), is(3));
-        assertThat(delta.getKillCount(), is(-1));
-    }
+  @Test
+  public void urlTransformPackageName() {
+    assertThat(moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation").getUrl(),
+               is("org_jenkinsci_plugins_pitmutation"));
+  }
 
-    private MutationResult packageResult() {
-        return projectResult.getChildResult("test_report").getChildResult("org.jenkinsci.plugins.pitmutation");
-    }
+  @Test
+  public void urlTransformClassName() {
+    assertThat(moduleResult
+                 .getChildMap()
+                 .get("org.jenkinsci.plugins.pitmutation")
+                 .getChildMap()
+                 .get("org.jenkinsci.plugins.pitmutation.PitParser")
+                 .getUrl(), is("org_jenkinsci_plugins_pitmutation_PitParser"));
+  }
 
-    @Test
-    public void packageResultsStatsDelta() {
-        MutationStats delta = packageResult().getStatsDelta();
-        assertThat(delta.getTotalMutations(), is(3));
-        assertThat(delta.getKillCount(), is(-1));
-    }
+  @Test
+  public void findsMutationsOnPitParserClass() {
+    MutationResult<?> pitPackage = moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation");
+    assertThat(pitPackage.getChildren(), hasSize(5));
+    MutationResult<?> pitParser = pitPackage.getChildMap().get("org.jenkinsci.plugins.pitmutation.PitParser");
+    assertThat(pitParser.getChildren(), hasSize(3));
+  }
 
-    private MutationResult classResult(String className) {
-        return packageResult().getChildResult(className);
-    }
+  @Test
+  public void collectsMutationStats() {
+    MutationStats stats = projectResult.getMutationStats();
+    assertThat(stats.getTotalMutations(), is(19));
+    assertThat(stats.getUndetected(), is(15));
+  }
 
-    @Test
-    public void classResultsStats() {
-        MutationStats stats = classResult("org.jenkinsci.plugins.pitmutation.Mutation").getMutationStats();
-        assertThat(stats.getTotalMutations(), is(3));
-        assertThat(stats.getKillCount(), is(1));
-    }
+  @Test
+  public void correctSourceLevels() {
+    MutationResult<?> pitPackage = moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation");
+    MutationResult<?> pitParser = pitPackage.getChildMap().get("org.jenkinsci.plugins.pitmutation.PitParser");
+    MutationResult<?> lineResult = pitParser.getChildMap().values().iterator().next();
 
-    @Test
-    public void classResultsStatsDelta() {
-        MutationStats delta = classResult("org.jenkinsci.plugins.pitmutation.Mutation").getStatsDelta();
-        assertThat(delta.getTotalMutations(), is(-1));
-        assertThat(delta.getKillCount(), is(-2));
-    }
+    assertThat(projectResult.isSourceLevel(), is(false));
+    assertThat(moduleResult.isSourceLevel(), is(false));
+    assertThat(pitPackage.isSourceLevel(), is(false));
+    assertThat(pitParser.isSourceLevel(), is(true));
+    assertThat(lineResult.isSourceLevel(), is(false));
+  }
 
-    @Test
-    public void classResultsForNewClass() {
-        MutationStats stats = classResult("org.jenkinsci.plugins.pitmutation.NewMutatedClass").getMutationStats();
-        assertThat(stats.getTotalMutations(), is(1));
-        assertThat(stats.getKillCount(), is(0));
-    }
+  @Test
+  public void testXmlTransform() {
+    assertThat(MutationResult.xmlTransform("replace&and<and>"), is("replace&amp;and&lt;and&gt;"));
+  }
 
-    @Test
-    public void classResultsForNewClassDelta() {
-        MutationStats stats = classResult("org.jenkinsci.plugins.pitmutation.NewMutatedClass").getStatsDelta();
-        assertThat(stats.getTotalMutations(), is(1));
-        assertThat(stats.getKillCount(), is(0));
-    }
-
-    @Test
-    public void classResultsOrdered() {
-        Iterator<? extends MutationResult> classes = moduleResult.getChildren().iterator();
-        int undetected = classes.next().getMutationStats().getUndetected();
-
-        while (classes.hasNext()) {
-            MutationResult result = classes.next();
-            assertThat(result.getMutationStats().getUndetected(), lessThan(undetected));
-            undetected = result.getMutationStats().getUndetected();
-        }
-    }
-
-    @Test
-    public void urlTransformPackageName() {
-        assertThat(moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation").getUrl(),
-            is("org_jenkinsci_plugins_pitmutation"));
-    }
-
-    @Test
-    public void urlTransformClassName() {
-        assertThat(moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation")
-                .getChildMap().get("org.jenkinsci.plugins.pitmutation.PitParser").getUrl(),
-            is("org_jenkinsci_plugins_pitmutation_PitParser"));
-    }
-
-    @Test
-    public void findsMutationsOnPitParserClass() {
-        MutationResult<?> pitPackage = moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation");
-        assertThat(pitPackage.getChildren(), hasSize(5));
-        MutationResult<?> pitParser = pitPackage.getChildMap().get("org.jenkinsci.plugins.pitmutation.PitParser");
-        assertThat(pitParser.getChildren(), hasSize(3));
-    }
-
-    @Test
-    public void collectsMutationStats() {
-        MutationStats stats = projectResult.getMutationStats();
-        assertThat(stats.getTotalMutations(), is(19));
-        assertThat(stats.getUndetected(), is(15));
-    }
-
-    @Test
-    public void correctSourceLevels() {
-        MutationResult<?> pitPackage = moduleResult.getChildMap().get("org.jenkinsci.plugins.pitmutation");
-        MutationResult<?> pitParser = pitPackage.getChildMap().get("org.jenkinsci.plugins.pitmutation.PitParser");
-        MutationResult<?> lineResult = pitParser.getChildMap().values().iterator().next();
-
-        assertThat(projectResult.isSourceLevel(), is(false));
-        assertThat(moduleResult.isSourceLevel(), is(false));
-        assertThat(pitPackage.isSourceLevel(), is(false));
-        assertThat(pitParser.isSourceLevel(), is(true));
-        assertThat(lineResult.isSourceLevel(), is(false));
-    }
-
-    @Test
-    public void testXmlTransform() {
-        assertThat(MutationResult.xmlTransform("replace&and<and>"), is("replace&amp;and&lt;and&gt;"));
-    }
-
-    @Test
-    public void testUrlTransform() {
-        assertThat(MutationResult.urlTransform("^*!replace::non+'alphas@}129"), is("___replace__non__alphas__129"));
-    }
+  @Test
+  public void testUrlTransform() {
+    assertThat(MutationResult.urlTransform("^*!replace::non+'alphas@}129"), is("___replace__non__alphas__129"));
+  }
 }

--- a/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutationStatsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pitmutation/targets/MutationStatsTest.java
@@ -1,7 +1,7 @@
 package org.jenkinsci.plugins.pitmutation.targets;
 
 import org.jenkinsci.plugins.pitmutation.Mutation;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
@@ -15,10 +15,10 @@ import static org.mockito.Mockito.when;
  * Date: 17/03/13
  * Time: 09:50
  */
-public class MutationStatsTest {
+class MutationStatsTest {
 
     @Test
-    public void killPercentCorrectlyCalculated() {
+    void killPercentCorrectlyCalculated() {
         MutationStats stats = new MutationStats() {
 
             @Override
@@ -41,7 +41,7 @@ public class MutationStatsTest {
     }
 
     @Test
-    public void mutationStatsImplTest() {
+    void mutationStatsImplTest() {
         MutationStats a = createMutationStatsA();
         MutationStats b = createMutationStatsB();
         assertThat(a.getTitle(), is("test"));
@@ -54,7 +54,7 @@ public class MutationStatsTest {
     }
 
     @Test
-    public void mutationStatsDelta() {
+    void mutationStatsDelta() {
         MutationStats delta = createMutationStatsA().delta(createMutationStatsB());
 
         assertThat(delta.getTotalMutations(), is(0));

--- a/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-00-new.xml
+++ b/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-00-new.xml
@@ -1,0 +1,386 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mutations>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>RabbitMqMessageListenerServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.rabbitmq.impl.RabbitMqMessageListenerServiceImpl</mutatedClass>
+        <mutatedMethod>onMessage</mutatedMethod>
+        <methodDescription>(Lcom/stayble/rabbitmq/binding/messages/BadgeLogMessage;)V</methodDescription>
+        <lineNumber>30</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+        <indexes>
+            <index>25</index>
+        </indexes>
+        <blocks>
+            <block>5</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.rabbitmq.impl.RabbitMqMessageListenerServiceImplTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.rabbitmq.impl.RabbitMqMessageListenerServiceImplTest]/[method:onPasswordResetRequestedMessage()]
+        </killingTest>
+        <description>removed call to com/stayble/badge_log/service/BadgeRequestLogService::logBadgeRequest</description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBadgeInfo</mutatedMethod>
+        <methodDescription>(Ljava/lang/String;)Lcom/stayble/badge/service/to/ProductBadgeInfo;</methodDescription>
+        <lineNumber>115</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
+        <indexes>
+            <index>5</index>
+        </indexes>
+        <blocks>
+            <block>1</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeProductInfo_okEmptyProductId()]
+        </killingTest>
+        <description>negated conditional</description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBadgeInfo</mutatedMethod>
+        <methodDescription>(Ljava/lang/String;)Lcom/stayble/badge/service/to/ProductBadgeInfo;</methodDescription>
+        <lineNumber>118</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+        <indexes>
+            <index>32</index>
+        </indexes>
+        <blocks>
+            <block>7</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeProductInfo_okEmptyProductId()]
+        </killingTest>
+        <description>replaced return value with null for
+            com/stayble/badge_log/service/BadgeRequestLogServiceImpl::getBadgeInfo
+        </description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBadgeStatus</mutatedMethod>
+        <methodDescription>
+            (Lcom/stayble/data/entity/Product;Lcom/stayble/data/entity/Retailer;)Lcom/stayble/data/enums/BadgeStatus;
+        </methodDescription>
+        <lineNumber>86</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
+        <indexes>
+            <index>4</index>
+        </indexes>
+        <blocks>
+            <block>0</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeStatus_okUpToDate()]
+        </killingTest>
+        <description>negated conditional</description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBadgeStatus</mutatedMethod>
+        <methodDescription>
+            (Lcom/stayble/data/entity/Product;Lcom/stayble/data/entity/Retailer;)Lcom/stayble/data/enums/BadgeStatus;
+        </methodDescription>
+        <lineNumber>89</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
+        <indexes>
+            <index>17</index>
+        </indexes>
+        <blocks>
+            <block>3</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeStatus_okUpToDate()]
+        </killingTest>
+        <description>negated conditional</description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBadgeStatus</mutatedMethod>
+        <methodDescription>
+            (Lcom/stayble/data/entity/Product;Lcom/stayble/data/entity/Retailer;)Lcom/stayble/data/enums/BadgeStatus;
+        </methodDescription>
+        <lineNumber>92</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
+        <indexes>
+            <index>30</index>
+        </indexes>
+        <blocks>
+            <block>6</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeStatus_okGrace()]
+        </killingTest>
+        <description>negated conditional</description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBadgeStatus</mutatedMethod>
+        <methodDescription>
+            (Lcom/stayble/data/entity/Product;Lcom/stayble/data/entity/Retailer;)Lcom/stayble/data/enums/BadgeStatus;
+        </methodDescription>
+        <lineNumber>90</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+        <indexes>
+            <index>21</index>
+        </indexes>
+        <blocks>
+            <block>4</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeStatus_okUpToDate()]
+        </killingTest>
+        <description>replaced return value with null for
+            com/stayble/badge_log/service/BadgeRequestLogServiceImpl::getBadgeStatus
+        </description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBadgeStatus</mutatedMethod>
+        <methodDescription>
+            (Lcom/stayble/data/entity/Product;Lcom/stayble/data/entity/Retailer;)Lcom/stayble/data/enums/BadgeStatus;
+        </methodDescription>
+        <lineNumber>93</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+        <indexes>
+            <index>34</index>
+        </indexes>
+        <blocks>
+            <block>7</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeStatus_okNotUpToDate()]
+        </killingTest>
+        <description>replaced return value with null for
+            com/stayble/badge_log/service/BadgeRequestLogServiceImpl::getBadgeStatus
+        </description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBadgeStatus</mutatedMethod>
+        <methodDescription>
+            (Lcom/stayble/data/entity/Product;Lcom/stayble/data/entity/Retailer;)Lcom/stayble/data/enums/BadgeStatus;
+        </methodDescription>
+        <lineNumber>95</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+        <indexes>
+            <index>39</index>
+        </indexes>
+        <blocks>
+            <block>8</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeStatus_okGrace()]
+        </killingTest>
+        <description>replaced return value with null for
+            com/stayble/badge_log/service/BadgeRequestLogServiceImpl::getBadgeStatus
+        </description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBrandName</mutatedMethod>
+        <methodDescription>(Ljava/lang/String;)Ljava/lang/String;</methodDescription>
+        <lineNumber>101</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
+        <indexes>
+            <index>5</index>
+        </indexes>
+        <blocks>
+            <block>1</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:logBadgeRequest_okWithBlankBrand()]
+        </killingTest>
+        <description>negated conditional</description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>getBrandName</mutatedMethod>
+        <methodDescription>(Ljava/lang/String;)Ljava/lang/String;</methodDescription>
+        <lineNumber>101</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.EmptyObjectReturnValsMutator</mutator>
+        <indexes>
+            <index>13</index>
+        </indexes>
+        <blocks>
+            <block>4</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:logBadgeRequest_okWithBlankBrand()]
+        </killingTest>
+        <description>replaced return value with &quot;&quot; for
+            com/stayble/badge_log/service/BadgeRequestLogServiceImpl::getBrandName
+        </description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>lambda$getBadgeInfo$2</mutatedMethod>
+        <methodDescription>(Lcom/stayble/data/entity/Product;)Lcom/stayble/badge/service/to/ProductBadgeInfo;
+        </methodDescription>
+        <lineNumber>121</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+        <indexes>
+            <index>10</index>
+        </indexes>
+        <blocks>
+            <block>2</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeProductInfo_okProductBadge()]
+        </killingTest>
+        <description>replaced return value with null for
+            com/stayble/badge_log/service/BadgeRequestLogServiceImpl::lambda$getBadgeInfo$2
+        </description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>lambda$getBadgeInfo$3</mutatedMethod>
+        <methodDescription>(Ljava/lang/String;)Lcom/stayble/badge/service/to/ProductBadgeInfo;</methodDescription>
+        <lineNumber>122</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+        <indexes>
+            <index>25</index>
+        </indexes>
+        <blocks>
+            <block>6</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:getBadgeProductInfo_okNewGtinBadge()]
+        </killingTest>
+        <description>replaced return value with null for
+            com/stayble/badge_log/service/BadgeRequestLogServiceImpl::lambda$getBadgeInfo$3
+        </description>
+    </mutation>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
+        <sourceFile>BadgeRequestLogServiceImpl.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.service.BadgeRequestLogServiceImpl</mutatedClass>
+        <mutatedMethod>logBadgeRequest</mutatedMethod>
+        <methodDescription>
+            (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+        </methodDescription>
+        <lineNumber>52</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+        <indexes>
+            <index>22</index>
+        </indexes>
+        <blocks>
+            <block>3</block>
+        </blocks>
+        <killingTest>
+            com.stayble.badge_log.service.BadgeRequestLogServiceTest.[engine:junit-jupiter]/[class:com.stayble.badge_log.service.BadgeRequestLogServiceTest]/[method:logBadgeRequest_okNotExistingLocationExceptionCatch()]
+        </killingTest>
+        <description>removed call to java/util/Optional::ifPresentOrElse</description>
+    </mutation>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
+        <sourceFile>TomcatLoggingConfiguration.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.configuration.TomcatLoggingConfiguration</mutatedClass>
+        <mutatedMethod>servletContainer</mutatedMethod>
+        <methodDescription>()Lorg/springframework/boot/web/servlet/server/ServletWebServerFactory;</methodDescription>
+        <lineNumber>17</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+        <indexes>
+            <index>17</index>
+        </indexes>
+        <blocks>
+            <block>2</block>
+        </blocks>
+        <killingTest/>
+        <description>removed call to ch/qos/logback/access/tomcat/LogbackValve::setAsyncSupported</description>
+    </mutation>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
+        <sourceFile>TomcatLoggingConfiguration.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.configuration.TomcatLoggingConfiguration</mutatedClass>
+        <mutatedMethod>servletContainer</mutatedMethod>
+        <methodDescription>()Lorg/springframework/boot/web/servlet/server/ServletWebServerFactory;</methodDescription>
+        <lineNumber>19</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+        <indexes>
+            <index>22</index>
+        </indexes>
+        <blocks>
+            <block>3</block>
+        </blocks>
+        <killingTest/>
+        <description>removed call to ch/qos/logback/access/tomcat/LogbackValve::setFilename</description>
+    </mutation>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
+        <sourceFile>TomcatLoggingConfiguration.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.configuration.TomcatLoggingConfiguration</mutatedClass>
+        <mutatedMethod>servletContainer</mutatedMethod>
+        <methodDescription>()Lorg/springframework/boot/web/servlet/server/ServletWebServerFactory;</methodDescription>
+        <lineNumber>21</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.VoidMethodCallMutator</mutator>
+        <indexes>
+            <index>32</index>
+        </indexes>
+        <blocks>
+            <block>4</block>
+        </blocks>
+        <killingTest/>
+        <description>removed call to
+            org/springframework/boot/web/embedded/tomcat/TomcatServletWebServerFactory::addContextValves
+        </description>
+    </mutation>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
+        <sourceFile>TomcatLoggingConfiguration.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.configuration.TomcatLoggingConfiguration</mutatedClass>
+        <mutatedMethod>servletContainer</mutatedMethod>
+        <methodDescription>()Lorg/springframework/boot/web/servlet/server/ServletWebServerFactory;</methodDescription>
+        <lineNumber>23</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+        <indexes>
+            <index>36</index>
+        </indexes>
+        <blocks>
+            <block>5</block>
+        </blocks>
+        <killingTest/>
+        <description>replaced return value with null for
+            com/stayble/badge_log/configuration/TomcatLoggingConfiguration::servletContainer
+        </description>
+    </mutation>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
+        <sourceFile>MethodTimingAspect.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.configuration.MethodTimingAspect</mutatedClass>
+        <mutatedMethod>measureExecutionTime</mutatedMethod>
+        <methodDescription>(Lorg/aspectj/lang/ProceedingJoinPoint;)Ljava/lang/Object;</methodDescription>
+        <lineNumber>18</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.MathMutator</mutator>
+        <indexes>
+            <index>14</index>
+        </indexes>
+        <blocks>
+            <block>3</block>
+        </blocks>
+        <killingTest/>
+        <description>Replaced long subtraction with addition</description>
+    </mutation>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
+        <sourceFile>MethodTimingAspect.java</sourceFile>
+        <mutatedClass>com.stayble.badge_log.configuration.MethodTimingAspect</mutatedClass>
+        <mutatedMethod>measureExecutionTime</mutatedMethod>
+        <methodDescription>(Lorg/aspectj/lang/ProceedingJoinPoint;)Ljava/lang/Object;</methodDescription>
+        <lineNumber>21</lineNumber>
+        <mutator>org.pitest.mutationtest.engine.gregor.mutators.returns.NullReturnValsMutator</mutator>
+        <indexes>
+            <index>19</index>
+        </indexes>
+        <blocks>
+            <block>3</block>
+        </blocks>
+        <killingTest/>
+        <description>replaced return value with null for
+            com/stayble/badge_log/configuration/MethodTimingAspect::measureExecutionTime
+        </description>
+    </mutation>
+</mutations>

--- a/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-00.xml
+++ b/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-00.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mutations>
-    <mutation detected='false' status='NO_COVERAGE'>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
         <sourceFile>PitParser.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.PitParser</mutatedClass>
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
@@ -11,7 +11,7 @@
         </indexes>
         <killingTest/>
     </mutation>
-    <mutation detected='false' status='NO_COVERAGE'>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
         <sourceFile>PitParser.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.PitParser</mutatedClass>
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
@@ -22,7 +22,7 @@
         </indexes>
         <killingTest/>
     </mutation>
-    <mutation detected='false' status='NO_COVERAGE'>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
         <sourceFile>PitParser.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.PitParser</mutatedClass>
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
@@ -34,7 +34,7 @@
         <killingTest/>
     </mutation>
 
-    <mutation detected='false' status='NO_COVERAGE'>
+    <mutation detected='false' status='NO_COVERAGE' numberOfTestsRun='0'>
         <sourceFile>Mutation.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.Mutation</mutatedClass>
         <mutatedMethod>equals</mutatedMethod>
@@ -45,7 +45,7 @@
         </indexes>
         <killingTest/>
     </mutation>
-    <mutation detected='true' status='KILLED'>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
         <sourceFile>Mutation.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.Mutation</mutatedClass>
         <mutatedMethod>setStatus</mutatedMethod>
@@ -58,7 +58,7 @@
             org.jenkinsci.plugins.pitmutation.MutationReportTest.canDigestAMutation(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>
     </mutation>
-    <mutation detected='true' status='KILLED'>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
         <sourceFile>Mutation.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.Mutation</mutatedClass>
         <mutatedMethod>getSourceFile</mutatedMethod>
@@ -71,7 +71,7 @@
             org.jenkinsci.plugins.pitmutation.MutationReportTest.canDigestAMutation(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>
     </mutation>
-    <mutation detected='true' status='KILLED'>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
         <sourceFile>Mutation.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.Mutation</mutatedClass>
         <mutatedMethod>getMutator</mutatedMethod>
@@ -85,7 +85,7 @@
         </killingTest>
     </mutation>
 
-    <mutation detected='false' status='SURVIVED'>
+    <mutation detected='false' status='SURVIVED' numberOfTestsRun='0'>
         <sourceFile>PitBuildAction.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.PitBuildAction</mutatedClass>
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
@@ -96,7 +96,7 @@
         </indexes>
         <killingTest/>
     </mutation>
-    <mutation detected='true' status='KILLED'>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
         <sourceFile>PitBuildAction.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.PitBuildAction</mutatedClass>
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
@@ -109,7 +109,7 @@
             org.jenkinsci.plugins.pitmutation.PitBuildActionTest.previousReturnsNullIfNoPreviousBuilds(org.jenkinsci.plugins.pitmutation.PitBuildActionTest)
         </killingTest>
     </mutation>
-    <mutation detected='false' status='SURVIVED'>
+    <mutation detected='false' status='SURVIVED' numberOfTestsRun='0'>
         <sourceFile>PitBuildAction.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.PitBuildAction</mutatedClass>
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
@@ -120,7 +120,7 @@
         </indexes>
         <killingTest/>
     </mutation>
-    <mutation detected='false' status='SURVIVED'>
+    <mutation detected='false' status='SURVIVED' numberOfTestsRun='0'>
         <sourceFile>PitBuildAction.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.PitBuildAction</mutatedClass>
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
@@ -132,7 +132,7 @@
         <killingTest/>
     </mutation>
 
-    <mutation detected='false' status='SURVIVED'>
+    <mutation detected='false' status='SURVIVED' numberOfTestsRun='0'>
         <sourceFile>MutationReport.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.MutationReport</mutatedClass>
         <mutatedMethod>digestMutations</mutatedMethod>
@@ -143,7 +143,7 @@
         </indexes>
         <killingTest/>
     </mutation>
-    <mutation detected='false' status='SURVIVED'>
+    <mutation detected='false' status='SURVIVED' numberOfTestsRun='0'>
         <sourceFile>MutationReport.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.MutationReport</mutatedClass>
         <mutatedMethod>digestMutations</mutatedMethod>
@@ -154,7 +154,7 @@
         </indexes>
         <killingTest/>
     </mutation>
-    <mutation detected='false' status='SURVIVED'>
+    <mutation detected='false' status='SURVIVED' numberOfTestsRun='0'>
         <sourceFile>MutationReport.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.MutationReport</mutatedClass>
         <mutatedMethod>digestMutations</mutatedMethod>
@@ -165,7 +165,7 @@
         </indexes>
         <killingTest/>
     </mutation>
-    <mutation detected='true' status='KILLED'>
+    <mutation detected='true' status='KILLED' numberOfTestsRun='0'>
         <sourceFile>MutationReport.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.MutationReport</mutatedClass>
         <mutatedMethod>digestMutations</mutatedMethod>
@@ -178,7 +178,7 @@
             org.jenkinsci.plugins.pitmutation.MutationReportTest.canDigestAMutation(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>
     </mutation>
-    <mutation detected='false' status='SURVIVED'>
+    <mutation detected='false' status='SURVIVED' numberOfTestsRun='0'>
         <sourceFile>MutationReport.java</sourceFile>
         <mutatedClass>org.jenkinsci.plugins.pitmutation.MutationReport</mutatedClass>
         <mutatedMethod>digestMutations</mutatedMethod>

--- a/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-00.xml
+++ b/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-00.xml
@@ -6,7 +6,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>28</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>10</index>
+        <indexes>
+            <index>10</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='NO_COVERAGE'>
@@ -15,7 +17,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>23</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>2</index>
+        <indexes>
+            <index>2</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='NO_COVERAGE'>
@@ -24,7 +28,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>26</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>7</index>
+        <indexes>
+            <index>7</index>
+        </indexes>
         <killingTest/>
     </mutation>
 
@@ -34,7 +40,9 @@
         <mutatedMethod>equals</mutatedMethod>
         <lineNumber>15</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-        <index>0</index>
+        <indexes>
+            <index>0</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='true' status='KILLED'>
@@ -43,7 +51,9 @@
         <mutatedMethod>setStatus</mutatedMethod>
         <lineNumber>36</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.MutationReportTest.canDigestAMutation(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>
@@ -54,7 +64,9 @@
         <mutatedMethod>getSourceFile</mutatedMethod>
         <lineNumber>40</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>
-        <index>5</index>
+        <indexes>
+            <index>5</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.MutationReportTest.canDigestAMutation(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>
@@ -65,7 +77,9 @@
         <mutatedMethod>getMutator</mutatedMethod>
         <lineNumber>72</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.ReturnValsMutator</mutator>
-        <index>9</index>
+        <indexes>
+            <index>9</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.MutationReportTest.canDigestAMutation(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>
@@ -77,7 +91,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>18</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>0</index>
+        <indexes>
+            <index>0</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='true' status='KILLED'>
@@ -86,7 +102,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>16</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-        <index>0</index>
+        <indexes>
+            <index>0</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.PitBuildActionTest.previousReturnsNullIfNoPreviousBuilds(org.jenkinsci.plugins.pitmutation.PitBuildActionTest)
         </killingTest>
@@ -97,7 +115,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>18</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-        <index>2</index>
+        <indexes>
+            <index>2</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='SURVIVED'>
@@ -106,7 +126,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>18</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest/>
     </mutation>
 
@@ -116,7 +138,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>42</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.InlineConstantMutator</mutator>
-        <index>2</index>
+        <indexes>
+            <index>2</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='SURVIVED'>
@@ -125,7 +149,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>39</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.InlineConstantMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='SURVIVED'>
@@ -134,7 +160,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>38</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.InlineConstantMutator</mutator>
-        <index>0</index>
+        <indexes>
+            <index>0</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='true' status='KILLED'>
@@ -143,7 +171,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>29</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.ConstructorCallMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.MutationReportTest.canDigestAMutation(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>
@@ -154,7 +184,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>39</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.InlineConstantMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest/>
     </mutation>
 </mutations>

--- a/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-01.xml
+++ b/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-01.xml
@@ -6,7 +6,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>28</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>10</index>
+        <indexes>
+            <index>10</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='NO_COVERAGE'>
@@ -15,7 +17,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>23</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>2</index>
+        <indexes>
+            <index>2</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='NO_COVERAGE'>
@@ -24,7 +28,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>26</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>7</index>
+        <indexes>
+            <index>7</index>
+        </indexes>
         <killingTest/>
     </mutation>
 
@@ -34,7 +40,9 @@
         <mutatedMethod>equals</mutatedMethod>
         <lineNumber>15</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-        <index>0</index>
+        <indexes>
+            <index>0</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='SURVIVED'>
@@ -43,7 +51,9 @@
         <mutatedMethod>setMutatedMethod</mutatedMethod>
         <lineNumber>60</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-        <index>4</index>
+        <indexes>
+            <index>4</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='true' status='KILLED'>
@@ -52,7 +62,9 @@
         <mutatedMethod>setStatus</mutatedMethod>
         <lineNumber>36</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.MutationReportTest.canDigestAMutation(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>
@@ -64,7 +76,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>18</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>0</index>
+        <indexes>
+            <index>0</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='true' status='KILLED'>
@@ -73,7 +87,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>16</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-        <index>0</index>
+        <indexes>
+            <index>0</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.PitBuildActionTest.previousReturnsNullIfNoPreviousBuilds(org.jenkinsci.plugins.pitmutation.PitBuildActionTest)
         </killingTest>
@@ -84,7 +100,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>18</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-        <index>2</index>
+        <indexes>
+            <index>2</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='SURVIVED'>
@@ -93,7 +111,9 @@
         <mutatedMethod>&#60;init&#62;</mutatedMethod>
         <lineNumber>17</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.MemberVariableMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='true' status='KILLED'>
@@ -102,7 +122,9 @@
         <mutatedMethod>getPreviousAction</mutatedMethod>
         <lineNumber>29</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>3</index>
+        <indexes>
+            <index>3</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.PitBuildActionTest.previousReturnsLastSuccessfulBuild(org.jenkinsci.plugins.pitmutation.PitBuildActionTest)
         </killingTest>
@@ -113,7 +135,9 @@
         <mutatedMethod>getBuildHealth</mutatedMethod>
         <lineNumber>40</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.ConstructorCallMutator</mutator>
-        <index>0</index>
+        <indexes>
+            <index>0</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='SURVIVED'>
@@ -122,7 +146,9 @@
         <mutatedMethod>getPreviousAction</mutatedMethod>
         <lineNumber>27</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NonVoidMethodCallMutator</mutator>
-        <index>2</index>
+        <indexes>
+            <index>2</index>
+        </indexes>
         <killingTest/>
     </mutation>
 
@@ -132,7 +158,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>42</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.InlineConstantMutator</mutator>
-        <index>2</index>
+        <indexes>
+            <index>2</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='SURVIVED'>
@@ -141,7 +169,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>39</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.InlineConstantMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='false' status='SURVIVED'>
@@ -150,7 +180,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>38</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.InlineConstantMutator</mutator>
-        <index>0</index>
+        <indexes>
+            <index>0</index>
+        </indexes>
         <killingTest/>
     </mutation>
     <mutation detected='true' status='KILLED'>
@@ -159,7 +191,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>29</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.ConstructorCallMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.MutationReportTest.canDigestAMutation(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>
@@ -170,7 +204,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>39</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.experimental.InlineConstantMutator</mutator>
-        <index>1</index>
+        <indexes>
+            <index>1</index>
+        </indexes>
         <killingTest/>
     </mutation>
 
@@ -180,7 +216,9 @@
         <mutatedMethod>digestMutations</mutatedMethod>
         <lineNumber>45</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.ConstructorCallMutator</mutator>
-        <index>5</index>
+        <indexes>
+            <index>5</index>
+        </indexes>
         <killingTest>
             org.jenkinsci.plugins.pitmutation.MutationReportTest.countsKills(org.jenkinsci.plugins.pitmutation.MutationReportTest)
         </killingTest>

--- a/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-02.xml
+++ b/src/test/resources/org/jenkinsci/plugins/pitmutation/testmutations-02.xml
@@ -9,7 +9,9 @@
         </methodDescription>
         <lineNumber>332</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-        <index>5</index>
+        <indexes>
+            <index>5</index>
+        </indexes>
         <killingTest/>
         <description>negated conditional</description>
     </mutation>
@@ -22,7 +24,9 @@
         </methodDescription>
         <lineNumber>342</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-        <index>47</index>
+        <indexes>
+            <index>47</index>
+        </indexes>
         <killingTest>es.rodri.MSInvoiceDetailTest.testController7(es.rodri.MSInvoiceDetailTest)</killingTest>
         <description>negated conditional</description>
     </mutation>
@@ -35,7 +39,9 @@
         </methodDescription>
         <lineNumber>344</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-        <index>56</index>
+        <indexes>
+            <index>56</index>
+        </indexes>
         <killingTest/>
         <description>negated conditional</description>
     </mutation>
@@ -48,7 +54,9 @@
         </methodDescription>
         <lineNumber>344</lineNumber>
         <mutator>org.pitest.mutationtest.engine.gregor.mutators.NegateConditionalsMutator</mutator>
-        <index>59</index>
+        <indexes>
+            <index>59</index>
+        </indexes>
         <killingTest/>
         <description>negated conditional</description>
     </mutation>


### PR DESCRIPTION
This pull request does several things:

- fixes https://issues.jenkins.io/browse/JENKINS-68990
- adds a ignoreMissingReports property used for projects which have the pitmutation plugin enabled but do not have units tests or do not generate mutation reports for whatever reason
- updates Junit4 to Junit5 and updates tests
- refactor PitPublisher and other classes to make code more testable
- add more unit tests
- sets the source level to Java 17
- updates dependencies in pom.xml to the latest version

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

The code was tested on a local Jenkins 2.401.2 instance on the project itself by creating a job, adding the pitmutation repo as source and trying to publish the mutation results in Jenkins. The single module behaviour was tested, the multimodule behaviour was not.  

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
